### PR TITLE
Update install script

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -307,8 +307,9 @@ try { $null = Get-Command dotnet -ErrorAction Stop; $dotnetAvailable = $true } c
 
 if ($dotnetAvailable) {
     $templatePkg = "Microsoft.WindowsAppSDK.WinUI.CSharp.Templates"
-    $existingTemplates = dotnet new list winui 2>$null
-    if ($existingTemplates -match "winui") {
+    $existingTemplates = $null
+    try { $existingTemplates = dotnet new list winui 2>$null } catch { }
+    if ($existingTemplates -and ($existingTemplates -match "winui")) {
         Write-Host "[OK] WinUI 3 templates already installed" -ForegroundColor Green
     } else {
         Write-Host "  Installing WinUI 3 templates from NuGet.org..." -ForegroundColor Gray


### PR DESCRIPTION
Fixed the WinUI 3 template detection in scripts/install.ps1 where the dotnet new list winui call now handles
errors gracefully with try/catch and adds a null-check before the -match test. Avoids exit with error when template not found.
<img width="666" height="177" alt="image" src="https://github.com/user-attachments/assets/74d10980-51cc-4e96-bffd-2a558966dbf9" />
