### PR TITLE
Dashboard: fix mid-run crash, run recovery, and progress view UX

### DIFF
--- a/agent-benchmark/dashboard/src/app.tsx
+++ b/agent-benchmark/dashboard/src/app.tsx
@@ -40,6 +40,7 @@ export function App({ showResultsOnly, runName: initialRunName, maxBuildMinutes 
   const [entries, setEntries] = useState<RunEntry[]>([]);
   const [runName, setRunName] = useState(initialRunName || "");
   const [configuredMaxBuildMinutes, setConfiguredMaxBuildMinutes] = useState(maxBuildMinutes);
+  const [configuredConcurrency, setConfiguredConcurrency] = useState(concurrency);
   const [startTime, setStartTime] = useState<Date | null>(null);
   const [elapsed, setElapsed] = useState("00:00:00");
   const queueRef = useRef<BenchmarkQueue | null>(null);
@@ -263,6 +264,16 @@ export function App({ showResultsOnly, runName: initialRunName, maxBuildMinutes 
         }
       }
 
+      // Restore run settings from run-meta.json
+      const metaPath = join(config.loadRunPath, "run-meta.json");
+      if (existsSync(metaPath)) {
+        try {
+          const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+          if (typeof meta.maxBuildMinutes === "number") setConfiguredMaxBuildMinutes(meta.maxBuildMinutes);
+          if (typeof meta.concurrency === "number") setConfiguredConcurrency(meta.concurrency);
+        } catch {}
+      }
+
       setView("results");
       return;
     }
@@ -270,6 +281,7 @@ export function App({ showResultsOnly, runName: initialRunName, maxBuildMinutes 
     const name = getNextRunName();
     setRunName(name);
     setConfiguredMaxBuildMinutes(config.maxBuildMinutes);
+    setConfiguredConcurrency(config.concurrency);
     const runDir = join(resultsRoot, name);
     mkdirSync(runDir, { recursive: true });
 
@@ -397,7 +409,7 @@ export function App({ showResultsOnly, runName: initialRunName, maxBuildMinutes 
     const queue = new BenchmarkQueue(
       rerunEntries,
       runDir,
-      { maxBuildMinutes: configuredMaxBuildMinutes, maxContinues: 50, concurrency: 3 },
+      { maxBuildMinutes: configuredMaxBuildMinutes, maxContinues: 50, concurrency: configuredConcurrency },
       {
         onOutput: (entryId, data) => {
           const prev = outputMapRef.current.get(entryId) || "";
@@ -413,7 +425,7 @@ export function App({ showResultsOnly, runName: initialRunName, maxBuildMinutes 
     queue.start().catch((err) => {
       console.error("Rerun queue error:", err);
     });
-  }, [entries, runName, configuredMaxBuildMinutes]);
+  }, [entries, runName, configuredMaxBuildMinutes, configuredConcurrency]);
 
   const handleRevalidate = useCallback(async (entryIds: string[]) => {
     const runDir = join(resultsRoot, runName);

--- a/agent-benchmark/dashboard/src/app.tsx
+++ b/agent-benchmark/dashboard/src/app.tsx
@@ -105,6 +105,12 @@ export function App({ showResultsOnly, runName: initialRunName, maxBuildMinutes 
 
   // Keyboard navigation
   useInput((input, key) => {
+    // Skip all app-level key handling during setup — setup view manages its own input
+    if (view === "setup") {
+      if (input === "q") exit();
+      return;
+    }
+
     // View switching (reset scroll when changing views)
     if (input === "1") { setView("live"); setScrollOffset(0); }
     else if (input === "2") { setView("progress"); setScrollOffset(0); }
@@ -120,12 +126,12 @@ export function App({ showResultsOnly, runName: initialRunName, maxBuildMinutes 
       setScrollOffset(0);
     }
 
-    // Scroll with ↑↓ (works in all views EXCEPT progress when done — progress uses ↑↓ for rerun selection)
-    const allDone = entries.length > 0 && entries.every(e => ["done", "failed", "timeout"].includes(e.status));
-    const progressUsesArrows = view === "progress" && allDone;
+    // Scroll with ↑↓ (skip when progress owns keys — it has its own virtual scroll)
+    const noneActive = entries.length > 0 && !entries.some(e => ["setup", "building", "build_done", "dotnet_build", "launching", "validating", "retrospective"].includes(e.status));
+    const progressOwnsKeys = view === "progress" && noneActive && !queueRef.current?.isRunning;
     const resultsUsesArrows = view === "results";
 
-    if (!progressUsesArrows && !resultsUsesArrows) {
+    if (!progressOwnsKeys && !resultsUsesArrows) {
       if (key.upArrow) {
         setScrollOffset(prev => prev + 3);
       } else if (key.downArrow) {
@@ -141,18 +147,21 @@ export function App({ showResultsOnly, runName: initialRunName, maxBuildMinutes 
         setResultsCursorIndex(prev => prev + 1); // clamped in ResultsView
       }
     }
-    if (key.pageUp || input === "[") {
-      const pageSize = (process.stdout.rows || 30) - 8;
-      setScrollOffset(prev => prev + pageSize);
-    } else if (key.pageDown || input === "]") {
-      const pageSize = (process.stdout.rows || 30) - 8;
-      setScrollOffset(prev => Math.max(0, prev - pageSize));
-    } else if (input === "e") {
-      setScrollOffset(0); // End — jump to bottom
-    } else if (input === "h") {
-      // Home — jump to top
-      const totalLines = (outputMapRef.current.get(entries[selectedRunIndex]?.id || "") || "").split("\n").length;
-      setScrollOffset(totalLines);
+    // Don't modify scrollOffset when progress view owns keys (it has its own virtual scroll)
+    if (!progressOwnsKeys) {
+      if (key.pageUp || input === "[") {
+        const pageSize = (process.stdout.rows || 30) - 8;
+        setScrollOffset(prev => prev + pageSize);
+      } else if (key.pageDown || input === "]") {
+        const pageSize = (process.stdout.rows || 30) - 8;
+        setScrollOffset(prev => Math.max(0, prev - pageSize));
+      } else if (input === "e") {
+        setScrollOffset(0); // End — jump to bottom
+      } else if (input === "h") {
+        // Home — jump to top
+        const totalLines = (outputMapRef.current.get(entries[selectedRunIndex]?.id || "") || "").split("\n").length;
+        setScrollOffset(totalLines);
+      }
     }
 
     // Live view specific: run selection with ←→
@@ -213,8 +222,8 @@ export function App({ showResultsOnly, runName: initialRunName, maxBuildMinutes 
       shellOpen(join(resultsRoot, runName));
     }
 
-    // H = generate HTML report and open it
-    if (input === "h" && runName) {
+    // H = generate HTML report and open it (skip when progress view uses h/H for navigation)
+    if (input === "h" && runName && !progressOwnsKeys) {
       const rd = join(resultsRoot, runName);
       const reportPath = generateHtmlReport(entries, rd);
       shellOpen(reportPath);
@@ -241,7 +250,10 @@ export function App({ showResultsOnly, runName: initialRunName, maxBuildMinutes 
 
       // Load session logs into output map for live view
       for (const entry of loaded.entries) {
-        const trialDir = join(config.loadRunPath, entry.scenarioConfigName, entry.trialName);
+        // Try flat structure first (new), then nested (old runs)
+        const flatDir = join(config.loadRunPath, entry.trialName);
+        const nestedDir = join(config.loadRunPath, entry.scenarioConfigName, entry.trialName);
+        const trialDir = existsSync(flatDir) ? flatDir : nestedDir;
         const logFile = join(trialDir, "session-log.txt");
         if (existsSync(logFile)) {
           try {
@@ -328,7 +340,9 @@ export function App({ showResultsOnly, runName: initialRunName, maxBuildMinutes 
       }
     );
     queueRef.current = queue;
-    queue.start();
+    queue.start().catch((err) => {
+      console.error("Queue error:", err);
+    });
   }, []);
 
   // Quick-run mode: auto-start with CLI args (--scenario X --agent Y --model Z)
@@ -396,7 +410,9 @@ export function App({ showResultsOnly, runName: initialRunName, maxBuildMinutes 
       }
     );
     queueRef.current = queue;
-    queue.start();
+    queue.start().catch((err) => {
+      console.error("Rerun queue error:", err);
+    });
   }, [entries, runName, configuredMaxBuildMinutes]);
 
   const handleRevalidate = useCallback(async (entryIds: string[]) => {
@@ -467,8 +483,8 @@ export function App({ showResultsOnly, runName: initialRunName, maxBuildMinutes 
           totalRuns={entries.length}
         />
       )}
-      <Box flexDirection="column" overflow="hidden" flexGrow={1} marginTop={view !== "live" ? -scrollOffset : 0}>
-        {view === "progress" && <ProgressView entries={entries} runName={runName} elapsed={elapsed} onRerun={handleRerun} onRevalidate={handleRevalidate} />}
+      <Box flexDirection="column" overflow="hidden" flexGrow={1} marginTop={view !== "live" && view !== "progress" ? -scrollOffset : 0}>
+        {view === "progress" && <ProgressView entries={entries} runName={runName} elapsed={elapsed} isRunning={queueRef.current?.isRunning} onRerun={handleRerun} onRevalidate={handleRevalidate} />}
         {view === "results" && <ResultsView entries={entries} runDir={runName ? join(resultsRoot, runName) : undefined} cursorIndex={resultsCursorIndex} onCursorClamp={(max) => { if (resultsCursorIndex > max) setResultsCursorIndex(max); }} />}
         {view === "charts" && <ChartsView entries={entries} />}
         {view === "summary" && <SummaryView entries={entries} runDir={runName ? join(resultsRoot, runName) : undefined} />}

--- a/agent-benchmark/dashboard/src/runner/benchmark.ts
+++ b/agent-benchmark/dashboard/src/runner/benchmark.ts
@@ -2213,37 +2213,51 @@ export async function runBenchmark(
   }
   } // end if (entry.runs) for validation
 
+  // ─── SAVE RESULTS (before retrospective so data is preserved if retro crashes) ───
+  entry.finishedAt = new Date();
+  const runElapsed = entry.startedAt
+    ? Math.round((entry.finishedAt.getTime() - entry.startedAt.getTime()) / 1000)
+    : 0;
+  const elapsedStr = `${Math.floor(runElapsed / 60)}m ${runElapsed % 60}s`;
+  saveResults(trialDir, entry, scenarioConfig, usage);
+
   // ─── RETROSPECTIVE ─── (always runs if we have a build session)
   if (buildSessionId) {
     setStatus("retrospective");
     banner("RETROSPECTIVE (Opus)", "📝", "green");
 
-    const retroPrompt = loadRetrospectivePrompt();
-    const retroResult = await runCopilotProcess(
-      [
-        `--resume=${buildSessionId}`,
-        "-p",
-        retroPrompt,
-        "--yolo",
-        "--model",
-        "claude-opus-4.6",
-      ],
-      trialDir,
-      join(trialDir, "retrospective-events.jsonl"),
-      callbacks.onOutput,
-      undefined, // no token update
-      undefined, // no timeout
-    );
-    const retroText = eventsToReadableText(join(trialDir, "retrospective-events.jsonl"));
-    writeFileSync(join(trialDir, "retrospective-log.txt"), retroText);
-
-    const retroJson = parseValidationJson(retroText);
-    if (retroJson) {
-      writeFileSync(
-        join(trialDir, "retrospective.json"),
-        JSON.stringify(retroJson, null, 2)
+    try {
+      const retroPrompt = loadRetrospectivePrompt();
+      const retroResult = await runCopilotProcess(
+        [
+          `--resume=${buildSessionId}`,
+          "-p",
+          retroPrompt,
+          "--yolo",
+          "--model",
+          "claude-opus-4.6",
+        ],
+        trialDir,
+        join(trialDir, "retrospective-events.jsonl"),
+        callbacks.onOutput,
+        undefined, // no token update
+        5 * 60 * 1000, // 5 minute timeout for retrospective
       );
-      (entry as any)._retroData = retroJson;
+      const retroText = eventsToReadableText(join(trialDir, "retrospective-events.jsonl"));
+      writeFileSync(join(trialDir, "retrospective-log.txt"), retroText);
+
+      const retroJson = parseValidationJson(retroText);
+      if (retroJson) {
+        writeFileSync(
+          join(trialDir, "retrospective.json"),
+          JSON.stringify(retroJson, null, 2)
+        );
+        (entry as any)._retroData = retroJson;
+        // Re-save results with retrospective data included
+        saveResults(trialDir, entry, scenarioConfig, usage);
+      }
+    } catch (err) {
+      log(`  ⚠️ Retrospective failed: ${err}`);
     }
   }
 
@@ -2251,14 +2265,8 @@ export async function runBenchmark(
   banner("CLEANUP & RESULTS", "✅", "green");
   await cleanupApps();
 
-  // ─── SAVE RESULTS ───
+  // ─── FINALIZE ───
   setStatus(entry.failReason ? "failed" : "done");
-  entry.finishedAt = new Date();
-  const runElapsed = entry.startedAt
-    ? Math.round((entry.finishedAt.getTime() - entry.startedAt.getTime()) / 1000)
-    : 0;
-  const elapsedStr = `${Math.floor(runElapsed / 60)}m ${runElapsed % 60}s`;
-  saveResults(trialDir, entry, scenarioConfig, usage);
 
   banner(`DONE: ${entry.score ?? 0}/100 in ${elapsedStr}`, entry.failReason ? "❌" : "✅", entry.failReason ? "red" : "green");
   log(`  Build: ${entry.builds ? "✅" : "❌"} | Run: ${entry.runs ? "✅" : "❌"} | Score: ${entry.score ?? 0}/100`);

--- a/agent-benchmark/dashboard/src/runner/config.ts
+++ b/agent-benchmark/dashboard/src/runner/config.ts
@@ -379,6 +379,70 @@ export function loadRunFromDisk(
     }
   }
 
+  // ── Reconstruct missing entries from run-meta.json ──
+  // If run-meta.json exists, rebuild the full matrix so incomplete runs
+  // show "queued" entries that can be rerun from the dashboard.
+  const metaPath = join(runDir, "run-meta.json");
+  if (existsSync(metaPath)) {
+    try {
+      const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+      const scenarios: string[] = Array.isArray(meta.scenarios) ? meta.scenarios : [];
+      const agents: string[] = Array.isArray(meta.agents) ? meta.agents : [];
+      const models: string[] = Array.isArray(meta.models) ? meta.models : [];
+      const iterations: number = typeof meta.iterations === "number" ? meta.iterations : 1;
+      const agentSetups = discoverAgentSetups();
+
+      // Build a set of already-loaded entry IDs for fast lookup
+      const loadedIds = new Set(entries.map(e => e.id));
+
+      for (let iter = 1; iter <= iterations; iter++) {
+        for (const scenarioName of scenarios) {
+          for (const agentName of agents) {
+            for (const model of models) {
+              const id = `${scenarioName}-${agentName}-${model}-iter${iter}`;
+              if (loadedIds.has(id)) continue; // already loaded from results.json
+              // Also check the alternate ID format used by loadRunFromDisk
+              const scenAcronym = scenarioName.split("-").map((w: string) => w[0]).join("");
+              const scenHash = Array.from(scenarioName).reduce((h: number, c: string) => (h * 31 + c.charCodeAt(0)) | 0, 0);
+              const scenShort = `${scenAcronym}${Math.abs(scenHash % 100).toString().padStart(2, "0")}`;
+              const modelShort = model.replace("claude-", "").replace("sonnet-", "s").replace("opus-", "o").replace(".", "");
+              const trialName = `${scenShort}_${agentName}_${modelShort}_i${iter}`;
+              const altId = `${scenarioName}/${trialName}`;
+              if (loadedIds.has(altId)) continue;
+
+              const scenarioPath = resolveScenarioPath(scenarioName);
+              const agentMatch = agentSetups.find(a => a.name === agentName);
+              const pluginPath = agentMatch?.path || "";
+              const iterLabel = iterations > 1 ? ` [${iter}/${iterations}]` : "";
+
+              // Check if trial directory exists (partially completed)
+              const trialDir = join(runDir, trialName);
+              const hasTrialDir = existsSync(trialDir);
+
+              entries.push({
+                id,
+                scenario: scenarioName,
+                scenarioPath,
+                scenarioConfigName: scenarioName,
+                condition: agentName + iterLabel,
+                pluginPath,
+                model,
+                trialName,
+                iteration: iter,
+                totalIterations: iterations,
+                status: hasTrialDir ? "failed" : "queued",
+                failReason: hasTrialDir ? "Interrupted (no results)" : undefined,
+                currentOutput: "",
+              });
+            }
+          }
+        }
+      }
+    } catch {
+      // If run-meta.json is unparseable, just use the results.json entries
+    }
+  }
+
   return { entries, runName };
 }
 

--- a/agent-benchmark/dashboard/src/views/progress.tsx
+++ b/agent-benchmark/dashboard/src/views/progress.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from "react";
-import { Box, Text, useInput } from "ink";
+import React, { useState, useMemo, useEffect } from "react";
+import { Box, Text, useInput, useStdout } from "ink";
 import type { RunEntry } from "../types.js";
 import { getGrade } from "../components/grades.js";
 
@@ -7,23 +7,78 @@ interface Props {
   entries: RunEntry[];
   runName: string;
   elapsed: string;
+  isRunning?: boolean;
   onRerun?: (entryIds: string[]) => void;
   onRevalidate?: (entryIds: string[]) => void;
 }
 
-export function ProgressView({ entries, runName, elapsed, onRerun, onRevalidate }: Props) {
+export function ProgressView({ entries, runName, elapsed, isRunning, onRerun, onRevalidate }: Props) {
   const completed = entries.filter(e => ["done", "failed", "timeout"].includes(e.status)).length;
-  const allDone = completed === entries.length && entries.length > 0;
+  // Allow selection when nothing is actively running (all done, or loaded run with queued entries)
+  const noneActive = entries.length > 0 && !entries.some(e => ["setup", "building", "build_done", "dotnet_build", "launching", "validating", "retrospective"].includes(e.status));
+  const allDone = noneActive && !isRunning;
   const [selectedForRerun, setSelectedForRerun] = useState<Set<string>>(new Set());
   const [cursorIndex, setCursorIndex] = useState(0);
 
+  // Fix #1: Clamp cursorIndex when entries shrink
+  useEffect(() => {
+    if (entries.length > 0 && cursorIndex >= entries.length) {
+      setCursorIndex(entries.length - 1);
+    }
+  }, [entries.length, cursorIndex]);
+
+  // Fix #2: Prune stale IDs from selectedForRerun when entries change
+  useEffect(() => {
+    const validIds = new Set(entries.map(e => e.id));
+    setSelectedForRerun(prev => {
+      const pruned = new Set([...prev].filter(id => validIds.has(id)));
+      return pruned.size !== prev.size ? pruned : prev;
+    });
+  }, [entries]);
+
+  // Virtual scrolling: compute visible window around cursor
+  const { stdout } = useStdout();
+  const termRows = stdout?.rows || 30;
+  // Account for ALL vertical overhead:
+  //   StatusBar (app.tsx): 3 lines (border-top, content, border-bottom)
+  //   Bottom help bar (app.tsx): 1 line
+  //   ProgressView padding={1}: 2 lines (top + bottom)
+  //   Header box with border: 4 lines (border-top, title, guide text, border-bottom)
+  //   Column headers + separator: 2 lines
+  //   Scroll indicators: 2 lines (above + below, worst case)
+  const totalOverhead = 14;
+  const maxVisible = Math.max(5, termRows - totalOverhead);
+
+  const { visibleEntries, scrollTop } = useMemo(() => {
+    const total = entries.length;
+    if (total <= maxVisible) {
+      return { visibleEntries: entries.map((e, i) => ({ entry: e, index: i })), scrollTop: 0 };
+    }
+    // Keep cursor roughly centered, clamped to bounds
+    let top = Math.max(0, cursorIndex - Math.floor(maxVisible / 2));
+    top = Math.min(top, total - maxVisible);
+    const slice = entries.slice(top, top + maxVisible).map((e, j) => ({ entry: e, index: top + j }));
+    return { visibleEntries: slice, scrollTop: top };
+  }, [entries, cursorIndex, maxVisible]);
+
   useInput((input, key) => {
-    if (!allDone) return; // Only allow selection when all runs are done
+    if (!allDone) return;
 
     if (key.upArrow) {
       setCursorIndex(i => Math.max(0, i - 1));
     } else if (key.downArrow) {
       setCursorIndex(i => Math.min(entries.length - 1, i + 1));
+    } else if (key.pageUp || input === "[") {
+      // Fix #6: Page navigation
+      setCursorIndex(i => Math.max(0, i - maxVisible));
+    } else if (key.pageDown || input === "]") {
+      setCursorIndex(i => Math.min(entries.length - 1, i + maxVisible));
+    } else if (input === "h") {
+      // Home — jump to top
+      setCursorIndex(0);
+    } else if (input === "e") {
+      // End — jump to bottom
+      setCursorIndex(entries.length - 1);
     } else if (input === " ") {
       // Toggle selection
       setSelectedForRerun(prev => {
@@ -31,6 +86,12 @@ export function ProgressView({ entries, runName, elapsed, onRerun, onRevalidate 
         const id = entries[cursorIndex]?.id;
         if (id) next.has(id) ? next.delete(id) : next.add(id);
         return next;
+      });
+    } else if (input === "a" || input === "A") {
+      // Toggle select all / deselect all
+      setSelectedForRerun(prev => {
+        if (prev.size === entries.length) return new Set();
+        return new Set(entries.map(e => e.id));
       });
     } else if (input === "r" || input === "R") {
       if (selectedForRerun.size > 0 && onRerun) {
@@ -53,7 +114,7 @@ export function ProgressView({ entries, runName, elapsed, onRerun, onRevalidate 
         </Text>
         {allDone && onRerun && (
           <Text color="gray">
-            ↑↓ navigate  |  Space: toggle  |  R: rerun  |  V: revalidate only ({selectedForRerun.size})
+            ↑↓ navigate  |  PgUp/PgDn: page  |  h/e: top/bottom  |  Space: toggle  |  A: select all  |  R: rerun selected  |  V: revalidate selected  |  Selected: {selectedForRerun.size}
           </Text>
         )}
       </Box>
@@ -64,19 +125,22 @@ export function ProgressView({ entries, runName, elapsed, onRerun, onRevalidate 
         <Text color="gray">
           {"  "}{"─".repeat(100)}
         </Text>
-        {entries.map((entry, i) => {
+        {scrollTop > 0 && <Text color="gray">  ↑ {scrollTop} more above</Text>}
+        {visibleEntries.map(({ entry, index: i }) => {
           const shortModel = entry.model.replace("claude-", "");
           const { text: statusText, color } = getStatusDisplay(entry);
           const isSelected = selectedForRerun.has(entry.id);
           const isCursor = allDone && i === cursorIndex;
-          const prefix = isCursor ? (isSelected ? "✓▶" : " ▶") : (isSelected ? "✓ " : "  ");
-          const lineNum = String(i + 1).padStart(2);
+          const prefix = isCursor ? (isSelected ? "✓▸" : " ▸") : (isSelected ? "✓ " : "  ");
+          const lineNum = String(i + 1).padStart(3);
+          const rowColor = isCursor ? "white" : isSelected ? "yellow" : color;
           return (
-            <Text key={entry.id} color={isSelected ? "yellow" : color} bold={isCursor}>
+            <Text key={entry.id} color={rowColor} bold={isCursor} inverse={isCursor}>
               {prefix}{lineNum}. {pad(entry.scenario, 20)} {pad(entry.condition, 32)} {pad(shortModel, 12)} {statusText}
             </Text>
           );
         })}
+        {scrollTop + maxVisible < entries.length && <Text color="gray">  ↓ {entries.length - scrollTop - maxVisible} more below</Text>}
       </Box>
     </Box>
   );


### PR DESCRIPTION
This PR fixes a crash that killed the dashboard mid-run, and addresses multiple UX issues in the progress view discovered during investigation.

## Changes (4 files, 7 scenarios)

### Fix Scenario 1: Dashboard crashes mid-run, losing all progress

**Broken:** The post-build analysis ("retrospective") phase had no timeout or error handling. When it failed, the entire dashboard crashed — losing the current trial's scores and preventing all remaining trials from ever running.

**Fixed:** Scores are saved before the retrospective runs. If the retrospective fails, it's logged and skipped — the dashboard moves on to the next trial.

**Details:**
- `benchmark.ts`: Moved `saveResults()` before retrospective. Wrapped retrospective in `try/catch`. Added 5-minute timeout (was `undefined`). Re-saves after successful retrospective to include retro data.
- `app.tsx`: Added `.catch()` to both `queue.start()` call sites.

---

### Fix Scenario 2: Reloading a crashed run shows only completed trials

**Broken:** After a crash, reopening the dashboard only showed trials that had finished successfully. Any interrupted or never-started trials were invisible and couldn't be rerun.

**Fixed:** The full run matrix is reconstructed from the saved run metadata when loading a previous run. Interrupted trials show as "failed", unstarted trials show as "queued". All can be selected and rerun.

**Details:**
- `config.ts`: `loadRunFromDisk()` reads `run-meta.json`, regenerates trial names using the same acronym+hash algorithm, and creates placeholder entries for missing trials.
- `app.tsx`: Session log loading tries flat path first, then nested, matching actual storage layout.

---

### Fix Scenario 3: Progress view unusable after loading a previous run

**Broken:** After loading a previous run, keyboard controls (↑↓ navigate, Space select, R rerun) did nothing — the view required all trials to be finished before allowing interaction.

**Fixed:** Keyboard controls are available whenever no trial is actively running, regardless of whether some trials are still queued.

**Details:**
- `progress.tsx`: `allDone` changed to `noneActive && !isRunning`.
- `app.tsx`: Passes `isRunning` prop. Updated `progressOwnsKeys` guard.

---

### Fix Scenario 4: Progress view renders incorrectly

**Broken:** When a run had more trials than the terminal could display, rows were hidden off-screen. The cursor moved through invisible rows — pressing ↓ appeared to do nothing (multiple presses between two visible rows). Some rows overlapped or flickered ("zippered" rendering).

**Fixed:** The list now scrolls virtually — only rows that fit the screen are rendered, and the view follows the cursor. Scroll indicators show how many entries are above/below. The selected row is clearly highlighted.

**Details:**
- `progress.tsx`: `useMemo` virtual scroll window. `useStdout()` for terminal height. `totalOverhead = 14`. Cursor uses `inverse + bold + white`. Selected rows show yellow with `✓`.
- `app.tsx`: Progress view excluded from `marginTop={-scrollOffset}`.

---

### Fix Scenario 5: Setup wizard keystrokes corrupt later views

**Broken:** While navigating the setup wizard (selecting runs, agents, etc.), arrow key presses were secretly scrolling the background view. After finishing setup, the status bar and top of the page were shifted off-screen.

**Fixed:** Setup wizard now fully owns keyboard input — background views are not affected.

**Details:**
- `app.tsx`: Early return in `useInput` when `view === "setup"`.

---

### Fix Scenario 6: Key conflicts between app and progress view

**Broken:** Some keys triggered two actions at once — e.g., pressing `h` both jumped to the top of the list *and* generated an HTML report. Page navigation keys conflicted with the progress view's own scrolling. After rerunning trials, stale selections could linger.

**Fixed:** When the progress view is active, it fully owns its navigation keys. Stale state (cursor position, selections) is automatically cleaned up when entries change.

**Details:**
- `app.tsx`: `H` and scroll keys guarded with `!progressOwnsKeys`.
- `progress.tsx`: `useEffect` clamps `cursorIndex`, prunes stale selection IDs. Added PageUp/PageDown/`h`/`e` for page navigation. Added `A` for select all toggle.

---

### Fix Scenario 7: Rerun ignores original run settings

**Broken:** When rerunning trials from a loaded run, the concurrency setting was hardcoded to 3 rather than read from the original run's configuration. For example, a run configured with `concurrency: 1` (sequential execution) would unexpectedly fire 3 trials in parallel on rerun.

**Fixed:** Run settings (concurrency, max build time) are restored from `run-meta.json` when loading a previous run and respected on rerun.

**Details:**
- `app.tsx`: Added `configuredConcurrency` state. Set from setup wizard on fresh runs, restored from `run-meta.json` on load. Rerun handler uses `configuredConcurrency` instead of hardcoded `3`.
