### PR TITLE
Improve dahsboard results page: cached token, premium requests, subagent costs by each.

### DIFF
--- a/agent-benchmark/README.md
+++ b/agent-benchmark/README.md
@@ -82,6 +82,35 @@ Switch views with number keys `1-5` or `Tab`:
 | 4 | Charts | Score vs tokens scatter plots |
 | 5 | Summary | AI-generated analysis |
 
+### Token & Cost Metrics
+
+The Results view (`3`) shows token usage and cost columns for each run. Select a row with `↑↓` to see a detail breakdown.
+
+**Tokens (main+subs)** — Total input tokens consumed by the copilot session.
+
+- **Main tokens**: Input tokens used by the main agent (the top-level copilot process). Sourced from `session.shutdown` → `modelMetrics.*.usage.inputTokens` in session-state.
+- **Sub-agent tokens**: Total tokens (input + output combined) consumed by sub-agents spawned via `task()`. Sourced from `subagent.completed` events in the JSONL stream. Shown as `935k + 755k` when sub-agents are present.
+
+> **Note:** Main and sub-agent token counts are **not additive** — the main session's `inputTokens` from `session.shutdown` already includes sub-agent usage. The sub-agent total from `subagent.completed` is shown separately to indicate how much work was delegated. The true overhead of the main agent alone is approximately `main - subs`.
+
+**Cached Tokens** — Input tokens served from the prompt cache rather than recomputed. Shown as absolute count + percentage, e.g., `803k (85.88%)`.
+
+- Sourced from `session.shutdown` → `modelMetrics.*.usage.cacheReadTokens`.
+- This is the **session-wide total** (main + sub-agents combined). Per-component cache breakdown is not available — sub-agent `session.shutdown` events do not include `modelMetrics`.
+- Higher cache % generally means lower cost, as cached tokens are billed at ~10% of the normal input rate.
+
+**Price** — Estimated cost based on Anthropic's direct API rates (not actual Copilot billing).
+
+- Computed in `pricing.ts` using per-model rates for input, cached, and output tokens.
+- Uncached input tokens are treated as cache **writes** at 2× base rate (assuming 1-hour cache lifetime). This is an approximation.
+- The estimate does **not** reflect actual GitHub Copilot billing, which uses premium requests as the billing unit.
+
+**Premium Requests** — The number of premium request units consumed by the session.
+
+- Sourced from the `result` event in the JSONL stream (`usage.premiumRequests`).
+- This counts the **main copilot session only**. Sub-agent premium request consumption is not reported separately by the copilot CLI.
+- For most single-agent runs, this is `1`. Multi-session runs (build + validation + retrospective) may show higher totals if read from `session.shutdown`.
+
 ### Keyboard shortcuts
 
 | Key | Action |

--- a/agent-benchmark/dashboard/src/runner/aggregate.ts
+++ b/agent-benchmark/dashboard/src/runner/aggregate.ts
@@ -18,6 +18,10 @@ export interface AggregatedEntry {
   avgInputTokens?: string;
   avgOutputTokens?: string;
   avgCachedTokens?: string;
+  avgPremiumRequests?: number;
+  avgSubAgentInputTokens?: string;
+  avgSubAgentCachedTokens?: string;
+  avgSubAgentCount?: number;
   avgPrice?: PriceEstimate;
   entries: RunEntry[];
 }
@@ -80,6 +84,20 @@ export function aggregateEntries(entries: RunEntry[]): AggregatedEntry[] {
       .map((e) => e.sessionTime!);
     const avgSession = sessionTimes.length > 0 ? sessionTimes[Math.floor(sessionTimes.length / 2)] : undefined;
 
+    // Average premium requests
+    const premiums = withScores.map((e) => e.premiumRequests ?? 0).filter((p) => p > 0);
+    const avgPremium = premiums.length > 0
+      ? Math.round(premiums.reduce((a, b) => a + b, 0) / premiums.length)
+      : undefined;
+
+    // Average sub-agent tokens
+    const subInputs = withScores.map((e) => parseTokenString(e.subAgentInputTokens || "0")).filter((t) => t > 0);
+    const avgSubIn = subInputs.length > 0 ? formatTokenCount(subInputs.reduce((a, b) => a + b, 0) / subInputs.length) : undefined;
+    const subCached = withScores.map((e) => parseTokenString(e.subAgentCachedTokens || "0")).filter((t) => t > 0);
+    const avgSubCached = subCached.length > 0 ? formatTokenCount(subCached.reduce((a, b) => a + b, 0) / subCached.length) : undefined;
+    const subCounts = withScores.map((e) => e.subAgentCount ?? 0).filter((c) => c > 0);
+    const avgSubCount = subCounts.length > 0 ? Math.round(subCounts.reduce((a, b) => a + b, 0) / subCounts.length) : undefined;
+
     result.push({
       scenario: group[0].scenario,
       condition: baseCondition,
@@ -95,6 +113,10 @@ export function aggregateEntries(entries: RunEntry[]): AggregatedEntry[] {
       avgInputTokens: avgIn,
       avgOutputTokens: avgOut,
       avgCachedTokens: avgCache,
+      avgPremiumRequests: avgPremium,
+      avgSubAgentInputTokens: avgSubIn,
+      avgSubAgentCachedTokens: avgSubCached,
+      avgSubAgentCount: avgSubCount,
       avgPrice,
       avgSessionTime: avgSession,
       entries: group,

--- a/agent-benchmark/dashboard/src/runner/benchmark.ts
+++ b/agent-benchmark/dashboard/src/runner/benchmark.ts
@@ -9,6 +9,7 @@ import {
   rmSync,
   copyFileSync,
   statSync,
+  symlinkSync,
 } from "fs";
 import { join, resolve } from "path";
 import {
@@ -22,6 +23,7 @@ import {
   loadSummaryPrompt,
   validateAgentSetupScripts,
 } from "./config.js";
+import { parseTokenString } from "../components/scatter-plot.js";
 import type { RunEntry, ScenarioConfig, AgentSetupConfig, GlobalConfig } from "../types.js";
 import { parse as parseYaml } from "yaml";
 import { platform } from "os";
@@ -253,6 +255,9 @@ interface CopilotProcessResult extends ProcessResult {
   tokenTotals: {
     mainOutput: number;
     subTotal: number;
+    subAgentTotalTokens: number;
+    subAgentCount: number;
+    subAgentDetails: Array<{ name: string; totalTokens: number; durationMs: number }>;
   };
 }
 
@@ -274,6 +279,9 @@ function runCopilotProcess(
     mainOutput: number;
     subTotal: number;
     premiumRequests: number;
+    subAgentTotalTokens: number;
+    subAgentCount: number;
+    subAgentDetails: Array<{ name: string; totalTokens: number; durationMs: number }>;
   }) => void,
   timeoutMs?: number,
 ): Promise<CopilotProcessResult> {
@@ -297,10 +305,13 @@ function runCopilotProcess(
     let mainOutputTokens = 0;
     let subTotalTokens = 0;
     let totalPremiumRequests = 0;
+    let subAgentTotalTokens = 0;  // totalTokens from subagent.completed (input+output)
+    let subAgentCount = 0;
+    const subAgentDetails: Array<{ name: string; totalTokens: number; durationMs: number }> = [];
 
     const fireTokenUpdate = () => {
       if (onTokenUpdate) {
-        onTokenUpdate({ mainOutput: mainOutputTokens, subTotal: subTotalTokens, premiumRequests: totalPremiumRequests });
+        onTokenUpdate({ mainOutput: mainOutputTokens, subTotal: subTotalTokens, premiumRequests: totalPremiumRequests, subAgentTotalTokens, subAgentCount, subAgentDetails });
       }
     };
 
@@ -340,7 +351,7 @@ function runCopilotProcess(
         timedOut,
         sessionId: resultEvent?.sessionId,
         usage: resultEvent?.usage,
-        tokenTotals: { mainOutput: mainOutputTokens, subTotal: subTotalTokens },
+        tokenTotals: { mainOutput: mainOutputTokens, subTotal: subTotalTokens, subAgentTotalTokens, subAgentCount, subAgentDetails },
       });
     };
 
@@ -457,8 +468,17 @@ function runCopilotProcess(
             const status = type === "subagent.completed" ? "✅" : "❌";
             const tokenInfo = ev.data.totalTokens ? ` (${ev.data.totalTokens} total tokens, ${ev.data.durationMs || 0}ms)` : "";
             onOutput(`\n${status} Sub-agent ${type.split(".")[1]}: ${ev.data.agentDisplayName || ev.data.agentName || "?"} ${ev.data.model || ""}${tokenInfo}\n`);
-            // Note: sub-agent output tokens are already tracked in real-time via
-            // assistant.message events with parentToolCallId — no need to add here
+            // Track sub-agent total tokens (input+output combined)
+            if (ev.data.totalTokens) {
+              subAgentTotalTokens += ev.data.totalTokens;
+              subAgentCount++;
+              subAgentDetails.push({
+                name: ev.data.agentDisplayName || ev.data.agentName || `sub-${subAgentCount}`,
+                totalTokens: ev.data.totalTokens,
+                durationMs: ev.data.durationMs || 0,
+              });
+              fireTokenUpdate();
+            }
           }
           break;
 
@@ -700,104 +720,117 @@ function formatDurationMs(ms: number): string {
 function aggregateSessionUsage(
   trialWorkDir: string,
   log: (msg: string) => void,
+  localSessionStateDir?: string,
 ): Record<string, any> | null {
-  const sessionStateDir = join(
-    process.env.HOME || process.env.USERPROFILE || "",
-    ".copilot",
-    "session-state"
-  );
+  // Prefer local session-state dir (from --config-dir) over global ~/.copilot
+  const sessionStateDir = localSessionStateDir && existsSync(localSessionStateDir)
+    ? localSessionStateDir
+    : join(process.env.HOME || process.env.USERPROFILE || "", ".copilot", "session-state");
   if (!existsSync(sessionStateDir)) return null;
 
-  // Normalize the trial dir path for comparison
+  // When using local session-state, skip cwd matching — all sessions belong to this trial
+  const useLocalDir = localSessionStateDir && existsSync(localSessionStateDir);
+
+  // Normalize the trial dir path for comparison (only needed for global dir scanning)
   const normalizedTrialDir = trialWorkDir.toLowerCase().replace(/[\\/]+/g, "/").replace(/\/$/, "");
 
   const sessionDirs = readdirSync(sessionStateDir, { withFileTypes: true })
-    .filter(d => d.isDirectory())
-    .map(d => ({
+    .filter((d: any) => d.isDirectory())
+    .map((d: any) => ({
       name: d.name,
       path: join(sessionStateDir, d.name),
       eventsPath: join(sessionStateDir, d.name, "events.jsonl"),
     }))
-    .filter(d => existsSync(d.eventsPath));
+    .filter((d: any) => existsSync(d.eventsPath));
 
-  // Aggregate across all matching sessions
-  const modelTotals: Record<string, { input: number; output: number; cached: number }> = {};
+  // Aggregate across all matching sessions — separate main vs sub-agent metrics
+  const mainModelTotals: Record<string, { input: number; output: number; cached: number }> = {};
+  const subModelTotals: Record<string, { input: number; output: number; cached: number }> = {};
   let totalPremium = 0;
   let totalApiMs = 0;
   let matchedSessions = 0;
   let totalAdded = 0;
   let totalRemoved = 0;
   let earliestStart = Infinity;
-  let latestEnd = 0;
+  let subAgentCount = 0;
 
   for (const sd of sessionDirs) {
     try {
-      const lines = readFileSync(sd.eventsPath, "utf-8").split("\n").filter(l => l.trim());
+      const lines = readFileSync(sd.eventsPath, "utf-8").split("\n").filter((l: string) => l.trim());
       if (lines.length === 0) continue;
 
-      // Check session.start cwd — must be within the trial directory
+      // Check session.start cwd — must be within the trial directory (skip check for local dir)
       const startEv = JSON.parse(lines[0]);
       if (startEv.type !== "session.start") continue;
-      const cwd = (startEv.data?.context?.cwd || "").toLowerCase().replace(/[\\/]+/g, "/").replace(/\/$/, "");
-      if (!cwd.startsWith(normalizedTrialDir)) continue;
+      if (!useLocalDir) {
+        const cwd = (startEv.data?.context?.cwd || "").toLowerCase().replace(/[\\/]+/g, "/").replace(/\/$/, "");
+        if (!cwd.startsWith(normalizedTrialDir)) continue;
+      }
 
       matchedSessions++;
       const sessionStartMs = new Date(startEv.data.startTime).getTime();
       if (sessionStartMs < earliestStart) earliestStart = sessionStartMs;
 
-      // Try to get data from session.shutdown first (most accurate)
-      let gotShutdown = false;
-      for (let i = lines.length - 1; i >= 0; i--) {
-        const ev = JSON.parse(lines[i]);
-        if (ev.type === "session.shutdown" && ev.data) {
-          gotShutdown = true;
-          const d = ev.data;
-          totalPremium += d.totalPremiumRequests || 0;
-          totalApiMs += d.totalApiDurationMs || 0;
-          if (d.codeChanges) {
-            totalAdded += d.codeChanges.linesAdded || 0;
-            totalRemoved += d.codeChanges.linesRemoved || 0;
-          }
-          if (d.modelMetrics) {
-            for (const [model, metrics] of Object.entries(d.modelMetrics)) {
-              const mu = (metrics as any).usage || {};
-              if (!modelTotals[model]) modelTotals[model] = { input: 0, output: 0, cached: 0 };
-              modelTotals[model].input += mu.inputTokens || 0;
-              modelTotals[model].output += mu.outputTokens || 0;
-              modelTotals[model].cached += mu.cacheReadTokens || 0;
-            }
-          }
-          break;
-        }
-      }
-
-      // Fallback: if no shutdown (process was killed), aggregate from assistant.message events
-      if (!gotShutdown) {
-        const model = startEv.data.selectedModel || "unknown";
-        if (!modelTotals[model]) modelTotals[model] = { input: 0, output: 0, cached: 0 };
-        for (const line of lines) {
-          const ev = JSON.parse(line);
-          if (ev.type === "assistant.message" && ev.data?.outputTokens) {
-            modelTotals[model].output += ev.data.outputTokens;
-          }
-        }
-        // Note: input/cached tokens aren't available per-message, only in shutdown
-      }
-
-      // Always check for sub-agent events (subagent.completed / subagent.failed)
-      // These track totalTokens for each sub-agent spawned via the task tool.
+      // Parse ALL session.shutdown events — classify as main vs sub-agent
+      // Sub-agent shutdowns: no shutdownType field
+      // Main session shutdown: shutdownType === "routine", has totalPremiumRequests
+      // Retrospective --resume shutdown: also "routine" but appears after main — skip
+      let mainFound = false;
       for (const line of lines) {
         try {
           const ev = JSON.parse(line);
-          if ((ev.type === "subagent.completed" || ev.type === "subagent.failed") && ev.data) {
-            const subModel = ev.data.model || "unknown";
-            if (!modelTotals[subModel]) modelTotals[subModel] = { input: 0, output: 0, cached: 0 };
-            // totalTokens includes input+output; attribute as input since most tokens are context
-            modelTotals[subModel].input += ev.data.totalTokens || 0;
-            totalApiMs += ev.data.durationMs || 0;
-            matchedSessions++; // Count sub-agents as additional sessions
+          if (ev.type !== "session.shutdown" || !ev.data) continue;
+
+          const d = ev.data;
+          const isRoutine = d.shutdownType === "routine";
+
+          if (isRoutine && !mainFound) {
+            // Main session — first routine shutdown
+            mainFound = true;
+            totalPremium += d.totalPremiumRequests || 0;
+            totalApiMs += d.totalApiDurationMs || 0;
+            if (d.codeChanges) {
+              totalAdded += d.codeChanges.linesAdded || 0;
+              totalRemoved += d.codeChanges.linesRemoved || 0;
+            }
+            if (d.modelMetrics) {
+              for (const [model, metrics] of Object.entries(d.modelMetrics)) {
+                const mu = (metrics as any).usage || {};
+                if (!mainModelTotals[model]) mainModelTotals[model] = { input: 0, output: 0, cached: 0 };
+                mainModelTotals[model].input += mu.inputTokens || 0;
+                mainModelTotals[model].output += mu.outputTokens || 0;
+                mainModelTotals[model].cached += mu.cacheReadTokens || 0;
+              }
+            }
+          } else if (!isRoutine && !d.shutdownType) {
+            // Sub-agent session — no shutdownType field
+            subAgentCount++;
+            if (d.modelMetrics) {
+              for (const [model, metrics] of Object.entries(d.modelMetrics)) {
+                const mu = (metrics as any).usage || {};
+                if (!subModelTotals[model]) subModelTotals[model] = { input: 0, output: 0, cached: 0 };
+                subModelTotals[model].input += mu.inputTokens || 0;
+                subModelTotals[model].output += mu.outputTokens || 0;
+                subModelTotals[model].cached += mu.cacheReadTokens || 0;
+              }
+            }
           }
+          // Skip subsequent routine shutdowns (retrospective --resume)
         } catch {}
+      }
+
+      // Fallback: if no shutdown (process was killed), aggregate from assistant.message events
+      if (!mainFound) {
+        const model = startEv.data.selectedModel || "unknown";
+        if (!mainModelTotals[model]) mainModelTotals[model] = { input: 0, output: 0, cached: 0 };
+        for (const line of lines) {
+          try {
+            const ev = JSON.parse(line);
+            if (ev.type === "assistant.message" && ev.data?.outputTokens) {
+              mainModelTotals[model].output += ev.data.outputTokens;
+            }
+          } catch {}
+        }
       }
     } catch {
       // Skip unparseable sessions
@@ -806,25 +839,34 @@ function aggregateSessionUsage(
 
   if (matchedSessions === 0) return null;
 
-  log(`  Session-state fallback: found ${matchedSessions} session(s) matching trial cwd`);
+  log(`  Session-state: found ${matchedSessions} session(s), ${subAgentCount} sub-agent shutdown(s)`);
 
   // Compute session duration from earliest start to now (best effort)
   const sessionDurationMs = earliestStart < Infinity
     ? Date.now() - earliestStart
     : 0;
 
-  // Build usage object in the same format as parseUsage
+  // Build usage object — includes both main and sub-agent breakdowns
   const usage: Record<string, any> = {
     premium_requests: totalPremium,
     api_time: totalApiMs > 0 ? formatDurationMs(totalApiMs) : undefined,
     session_time: sessionDurationMs > 0 ? formatDurationMs(sessionDurationMs) : undefined,
     models: {} as Record<string, { input: string; output: string; cached: string }>,
+    sub_agent_count: subAgentCount,
+    sub_agent_models: {} as Record<string, { input: string; output: string; cached: string }>,
   };
   if (totalAdded || totalRemoved) {
     usage.code_changes = `+${totalAdded} -${totalRemoved}`;
   }
-  for (const [model, totals] of Object.entries(modelTotals)) {
+  for (const [model, totals] of Object.entries(mainModelTotals)) {
     usage.models[model] = {
+      input: formatTokenCount(totals.input),
+      output: formatTokenCount(totals.output),
+      cached: formatTokenCount(totals.cached),
+    };
+  }
+  for (const [model, totals] of Object.entries(subModelTotals)) {
+    usage.sub_agent_models[model] = {
       input: formatTokenCount(totals.input),
       output: formatTokenCount(totals.output),
       cached: formatTokenCount(totals.cached),
@@ -1324,7 +1366,21 @@ export async function runBenchmark(
   // Flat trial folder directly under runDir (short paths avoid MAX_PATH issues)
   const trialDir = join(runDir, entry.trialName);
   const workDir = join(trialDir, "app");
+  const logsDir = join(trialDir, "session-logs-dir");
   mkdirSync(workDir, { recursive: true });
+  mkdirSync(logsDir, { recursive: true });
+
+  // Set up local .copilot config dir with symlinks so session-state writes locally
+  const trialConfigDir = join(logsDir, ".copilot");
+  mkdirSync(trialConfigDir, { recursive: true });
+  const globalCopilot = join(process.env.HOME || process.env.USERPROFILE || "", ".copilot");
+  for (const item of ["config.json", "session-store.db", "session-store.db-shm", "session-store.db-wal", "installed-plugins", "ide"]) {
+    const target = join(globalCopilot, item);
+    const link = join(trialConfigDir, item);
+    if (existsSync(target) && !existsSync(link)) {
+      try { symlinkSync(target, link); } catch { /* ignore if symlink fails */ }
+    }
+  }
 
   const setStatus = (status: RunEntry["status"]) => {
     entry.status = status;
@@ -1461,7 +1517,7 @@ export async function runBenchmark(
         JSON.stringify(
           {
             trial: entry.trialName,
-            scenario: scenarioConfig.name,
+            scenario: entry.scenarioConfigName,
             condition: entry.condition,
             model: entry.model,
             metrics: { score: 0, builds: false, runs: false, timeout: false },
@@ -1504,7 +1560,7 @@ export async function runBenchmark(
           BENCH_APP_DIR: workDir,
           BENCH_APP_NAME: appName,
           BENCH_SCENARIO_DIR: entry.scenarioPath,
-          BENCH_SCENARIO_NAME: scenarioConfig.name,
+          BENCH_SCENARIO_NAME: entry.scenarioConfigName,
           BENCH_AGENTSETUP_NAME: condShort,
           BENCH_AGENTSETUP_DIR: entry.pluginPath,
           BENCH_SCRIPT_DIR: script.scriptDir,
@@ -1532,7 +1588,7 @@ export async function runBenchmark(
           JSON.stringify(
             {
               trial: entry.trialName,
-              scenario: scenarioConfig.name,
+              scenario: entry.scenarioConfigName,
               condition: entry.condition,
               model: entry.model,
               metrics: { score: 0, builds: false, runs: false, timeout: false },
@@ -1911,7 +1967,7 @@ export async function runBenchmark(
   prompt += `\n\nDo NOT run any git operations (git add, git commit, git status, etc.) — focus only on building the app.`;
 
   // ── 7. Run copilot ──
-  const promptFile = join(trialDir, "build-prompt.txt");
+  const promptFile = join(logsDir, "build-prompt.txt");
   writeFileSync(promptFile, prompt);
 
   // Show the full prompt in the live view
@@ -1932,12 +1988,13 @@ export async function runBenchmark(
   ];
   if (agentFlag) copilotArgs.push("--agent", resolvedAgentName);
   if (mcpConfigPath) copilotArgs.push("--additional-mcp-config", `@${mcpConfigPath}`);
+  copilotArgs.push("--config-dir", trialConfigDir);
 
   entry.startedAt = new Date();
   const buildResult = await runCopilotProcess(
     copilotArgs,
     workDir,
-    join(trialDir, "build-events.jsonl"),
+    join(logsDir, "build-events.jsonl"),
     callbacks.onOutput,
     (totals) => {
       // Real-time token update — format rich display string
@@ -1950,12 +2007,18 @@ export async function runBenchmark(
         entry.tokenDisplay = `out: ${mainOut}`;
       }
       entry.outputTokens = formatTokenCount(totals.mainOutput);
+      entry.premiumRequests = totals.premiumRequests;
+      if (totals.subAgentTotalTokens > 0) {
+        entry.subAgentInputTokens = formatTokenCount(totals.subAgentTotalTokens);
+        entry.subAgentCount = totals.subAgentCount;
+        entry.subAgentDetails = totals.subAgentDetails;
+      }
       callbacks.onStatusChange(entry);
     },
     opts.maxBuildMinutes * 60 * 1000,
   );
 
-  writeFileSync(join(trialDir, "session-log.txt"), eventsToReadableText(join(trialDir, "build-events.jsonl")));
+  writeFileSync(join(logsDir, "session-log.txt"), eventsToReadableText(join(logsDir, "build-events.jsonl")));
 
   if (buildResult.timedOut) {
     banner(`TIMEOUT: Build exceeded ${opts.maxBuildMinutes} minutes`, "⏰", "red");
@@ -1967,7 +2030,7 @@ export async function runBenchmark(
       JSON.stringify(
         {
           trial: entry.trialName,
-          scenario: scenarioConfig.name,
+          scenario: entry.scenarioConfigName,
           condition: entry.condition,
           model: entry.model,
           metrics: { score: 0, builds: false, runs: false, timeout: true },
@@ -2021,17 +2084,26 @@ export async function runBenchmark(
 
   // Fallback: if parseUsage found no models (e.g., orchestrator agents that delegate to sub-agents),
   // aggregate token usage from copilot session-state events.jsonl files matching this trial's cwd.
+  const localSessionState = join(logsDir, ".copilot", "session-state");
   if (!usage.models || Object.keys(usage.models).length === 0) {
-    const sessionUsage = aggregateSessionUsage(workDir, log);
+    const sessionUsage = aggregateSessionUsage(workDir, log, localSessionState);
     if (sessionUsage) {
       usage = { ...usage, ...sessionUsage };
       log(`  Aggregated usage from session-state: ${Object.keys(sessionUsage.models || {}).length} model(s)`);
+    }
+  } else {
+    // Even when we have main model data, still aggregate to get sub-agent breakdown
+    const sessionUsage = aggregateSessionUsage(workDir, log, localSessionState);
+    if (sessionUsage) {
+      usage.sub_agent_count = sessionUsage.sub_agent_count;
+      usage.sub_agent_models = sessionUsage.sub_agent_models;
     }
   }
 
   entry.sessionTime = usage.session_time;
   entry.apiTime = usage.api_time;
   entry.codeChanges = usage.code_changes;
+  entry.premiumRequests = usage.premium_requests;
   if (usage.models) {
     const firstModel = Object.keys(usage.models)[0];
     if (firstModel) {
@@ -2040,11 +2112,32 @@ export async function runBenchmark(
       entry.cachedTokens = usage.models[firstModel].cached;
     }
   }
+  // Populate sub-agent token breakdown from session-state shutdown events
+  // (may be empty if sub-agent shutdowns lack modelMetrics)
+  if (usage.sub_agent_models && Object.keys(usage.sub_agent_models).length > 0) {
+    let subIn = 0, subCached = 0;
+    for (const m of Object.values(usage.sub_agent_models) as any[]) {
+      subIn += parseTokenString(m.input);
+      subCached += parseTokenString(m.cached);
+    }
+    entry.subAgentInputTokens = formatTokenCount(subIn);
+    entry.subAgentCachedTokens = formatTokenCount(subCached);
+    entry.subAgentCount = usage.sub_agent_count || 0;
+  } else if (buildResult.tokenTotals.subAgentTotalTokens > 0) {
+    // Fallback: use totalTokens from subagent.completed events (no cache breakdown)
+    entry.subAgentInputTokens = formatTokenCount(buildResult.tokenTotals.subAgentTotalTokens);
+    entry.subAgentCount = buildResult.tokenTotals.subAgentCount;
+    entry.subAgentDetails = buildResult.tokenTotals.subAgentDetails;
+    // Also store in usage for persistence
+    usage.sub_agent_count = buildResult.tokenTotals.subAgentCount;
+    usage.sub_agent_total_tokens = formatTokenCount(buildResult.tokenTotals.subAgentTotalTokens);
+    usage.sub_agent_details = buildResult.tokenTotals.subAgentDetails;
+  }
 
-  // Write aggregated session usage to trial dir
+  // Write aggregated session usage to logs dir
   if (Object.keys(usage).length > 0) {
     writeFileSync(
-      join(trialDir, "session-usage.json"),
+      join(logsDir, "session-usage.json"),
       JSON.stringify({
         build_session_id: buildSessionId || null,
         ...usage,
@@ -2061,7 +2154,7 @@ export async function runBenchmark(
       .replace(/\{app_dir\}/g, workDir)
       .replace(/\{app_name\}/g, appName)
       .replace(/\{csproj\}/g, customCsproj ? `"${customCsproj}"` : "");
-    entry.builds = await customBuild(expandedBuildCmd, workDir, trialDir, callbacks, log);
+    entry.builds = await customBuild(expandedBuildCmd, workDir, logsDir, callbacks, log);
     if (customCsproj) (entry as any)._csproj = customCsproj;
     log(`  ${entry.builds ? "PASS ✅" : "FAIL ❌"}`);
     if (!entry.builds) {
@@ -2072,7 +2165,7 @@ export async function runBenchmark(
     }
   } else {
     banner("DOTNET BUILD", "🔨", "cyan");
-    const dotnetResult = await defaultDotnetBuild(workDir, trialDir, globalConfig, callbacks, log);
+    const dotnetResult = await defaultDotnetBuild(workDir, logsDir, globalConfig, callbacks, log);
     if (!dotnetResult.csproj) {
       banner("FAILED: No .csproj found", "❌", "red");
       entry.builds = false;
@@ -2183,14 +2276,14 @@ export async function runBenchmark(
   valPrompt += `\n\n## Project source code location\nThe app source code is at: ${projectDir}\n`;
 
   const valResult = await runCopilotProcess(
-    ["-p", valPrompt, "--yolo", "--model", entry.model],
+    ["-p", valPrompt, "--yolo", "--model", entry.model, "--config-dir", trialConfigDir],
     trialDir,
-    join(trialDir, "validation-events.jsonl"),
+    join(logsDir, "validation-events.jsonl"),
     callbacks.onOutput,
     undefined, // no token update callback for validation
     40 * 60 * 1000,  // 40 minute hard timeout for validation
   );
-  writeFileSync(join(trialDir, "validation-log.txt"), eventsToReadableText(join(trialDir, "validation-events.jsonl")));
+  writeFileSync(join(logsDir, "validation-log.txt"), eventsToReadableText(join(logsDir, "validation-events.jsonl")));
 
   // Session ID from result event
   if (valResult.sessionId) {
@@ -2212,7 +2305,7 @@ export async function runBenchmark(
   }
 
   // Parse validation scores from the readable text (not raw JSONL events)
-  const validationText = eventsToReadableText(join(trialDir, "validation-events.jsonl"));
+  const validationText = eventsToReadableText(join(logsDir, "validation-events.jsonl"));
   let validation = parseValidationJson(validationText);
 
   // If validation timed out without producing JSON, ask for a follow-up scoring
@@ -2222,17 +2315,17 @@ export async function runBenchmark(
 
     const followUpPrompt = `You ran out of time during validation. Based on everything you've already checked and observed, output your evaluation JSON now. Do NOT do any more investigation — just score based on what you've seen so far. Output ONLY the JSON block in a \`\`\`json code fence.`;
     const followUpResult = await runCopilotProcess(
-      [`--resume=${entry.validationSessionId}`, "-p", followUpPrompt, "--yolo", "--model", entry.model],
+      [`--resume=${entry.validationSessionId}`, "-p", followUpPrompt, "--yolo", "--model", entry.model, "--config-dir", trialConfigDir],
       trialDir,
-      join(trialDir, "validation-followup-events.jsonl"),
+      join(logsDir, "validation-followup-events.jsonl"),
       callbacks.onOutput,
       undefined, // no token update
       5 * 60 * 1000,  // 5 minute timeout for follow-up
     );
 
     // Append follow-up transcript to validation log
-    const followUpText = "\n\n=== VALIDATION TIMEOUT FOLLOW-UP ===\n" + eventsToReadableText(join(trialDir, "validation-followup-events.jsonl"));
-    appendFileSync(join(trialDir, "validation-log.txt"), followUpText);
+    const followUpText = "\n\n=== VALIDATION TIMEOUT FOLLOW-UP ===\n" + eventsToReadableText(join(logsDir, "validation-followup-events.jsonl"));
+    appendFileSync(join(logsDir, "validation-log.txt"), followUpText);
 
     validation = parseValidationJson(followUpText);
     if (validation) {
@@ -2300,20 +2393,22 @@ export async function runBenchmark(
           "--yolo",
           "--model",
           "claude-opus-4.6",
+          "--config-dir",
+          trialConfigDir,
         ],
         trialDir,
-        join(trialDir, "retrospective-events.jsonl"),
+        join(logsDir, "retrospective-events.jsonl"),
         callbacks.onOutput,
         undefined, // no token update
         5 * 60 * 1000, // 5 minute timeout for retrospective
       );
-      const retroText = eventsToReadableText(join(trialDir, "retrospective-events.jsonl"));
-      writeFileSync(join(trialDir, "retrospective-log.txt"), retroText);
+      const retroText = eventsToReadableText(join(logsDir, "retrospective-events.jsonl"));
+      writeFileSync(join(logsDir, "retrospective-log.txt"), retroText);
 
       const retroJson = parseValidationJson(retroText);
       if (retroJson) {
         writeFileSync(
-          join(trialDir, "retrospective.json"),
+          join(logsDir, "retrospective.json"),
           JSON.stringify(retroJson, null, 2)
         );
         (entry as any)._retroData = retroJson;
@@ -2470,7 +2565,7 @@ function saveResults(
 
   const results: Record<string, any> = {
     trial: entry.trialName,
-    scenario: config.name,
+    scenario: entry.scenarioConfigName,
     condition: entry.condition,
     type: config.type,
     model: entry.model,

--- a/agent-benchmark/dashboard/src/runner/benchmark.ts
+++ b/agent-benchmark/dashboard/src/runner/benchmark.ts
@@ -308,6 +308,7 @@ function runCopilotProcess(
     let subAgentTotalTokens = 0;  // totalTokens from subagent.completed (input+output)
     let subAgentCount = 0;
     const subAgentDetails: Array<{ name: string; totalTokens: number; durationMs: number }> = [];
+    const taskNameMap = new Map<string, string>();  // toolCallId → custom task name
 
     const fireTokenUpdate = () => {
       if (onTokenUpdate) {
@@ -423,7 +424,10 @@ function runCopilotProcess(
           break;
 
         case "tool.execution_start":
-          // Tool start is already shown from assistant.message toolRequests
+          // Track task() tool calls to map toolCallId to custom agent name
+          if (ev.data?.toolName === "task" && ev.data?.arguments?.name && ev.data?.toolCallId) {
+            taskNameMap.set(ev.data.toolCallId, ev.data.arguments.description || ev.data.arguments.name);
+          }
           break;
 
         case "tool.execution_partial_result":
@@ -472,8 +476,9 @@ function runCopilotProcess(
             if (ev.data.totalTokens) {
               subAgentTotalTokens += ev.data.totalTokens;
               subAgentCount++;
+              const customName = taskNameMap.get(ev.data.toolCallId) || ev.data.agentDisplayName || ev.data.agentName || `sub-${subAgentCount}`;
               subAgentDetails.push({
-                name: ev.data.agentDisplayName || ev.data.agentName || `sub-${subAgentCount}`,
+                name: customName,
                 totalTokens: ev.data.totalTokens,
                 durationMs: ev.data.durationMs || 0,
               });

--- a/agent-benchmark/dashboard/src/runner/config.ts
+++ b/agent-benchmark/dashboard/src/runner/config.ts
@@ -9,6 +9,7 @@ import {
   ScriptEntry,
 } from "../types.js";
 import { parse as parseYaml } from "yaml";
+import { parseTokenString } from "../components/scatter-plot.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -229,6 +230,12 @@ export const AVAILABLE_MODELS = [
   "gpt-5.1",
 ];
 
+function formatTokenCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}m`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(Math.round(n));
+}
+
 // =============================================================================
 // Matrix Loading
 // =============================================================================
@@ -328,6 +335,25 @@ export function loadRunFromDisk(
         }
       }
 
+      // Extract sub-agent token info
+      let subAgentInputTokens: string | undefined;
+      let subAgentCachedTokens: string | undefined;
+      let subAgentCount: number | undefined;
+      if (tt.sub_agent_models && Object.keys(tt.sub_agent_models).length > 0) {
+        let subIn = 0, subCached = 0;
+        for (const m of Object.values(tt.sub_agent_models) as any[]) {
+          subIn += parseTokenString(m.input);
+          subCached += parseTokenString(m.cached);
+        }
+        subAgentInputTokens = subIn > 0 ? formatTokenCount(subIn) : undefined;
+        subAgentCachedTokens = subCached > 0 ? formatTokenCount(subCached) : undefined;
+        subAgentCount = tt.sub_agent_count || 0;
+      } else if (tt.sub_agent_total_tokens) {
+        // Fallback: totalTokens from subagent.completed (no cache breakdown)
+        subAgentInputTokens = tt.sub_agent_total_tokens;
+        subAgentCount = tt.sub_agent_count || 0;
+      }
+
       // Determine scenario path (best effort — check flat and nested group folders)
       const scenarioName = raw.scenario || "";
       const scenarioPath = resolveScenarioPath(scenarioName);
@@ -365,6 +391,11 @@ export function loadRunFromDisk(
         inputTokens,
         outputTokens,
         cachedTokens,
+        premiumRequests: tt.premium_requests,
+        subAgentInputTokens,
+        subAgentCachedTokens,
+        subAgentCount,
+        subAgentDetails: tt.sub_agent_details,
         failReason: m.score === 0 ? (m.timeout ? "Timeout" : !m.builds ? "Build failed" : !m.runs ? "App failed to run" : undefined) : undefined,
         currentOutput: "",
         startedAt: raw.timestamp ? new Date(raw.timestamp) : undefined,
@@ -392,8 +423,9 @@ export function loadRunFromDisk(
       const iterations: number = typeof meta.iterations === "number" ? meta.iterations : 1;
       const agentSetups = discoverAgentSetups();
 
-      // Build a set of already-loaded entry IDs for fast lookup
+      // Build a set of already-loaded entry IDs and trial names for fast lookup
       const loadedIds = new Set(entries.map(e => e.id));
+      const loadedTrialNames = new Set(entries.map(e => e.trialName));
 
       for (let iter = 1; iter <= iterations; iter++) {
         for (const scenarioName of scenarios) {
@@ -409,6 +441,10 @@ export function loadRunFromDisk(
               const trialName = `${scenShort}_${agentName}_${modelShort}_i${iter}`;
               const altId = `${scenarioName}/${trialName}`;
               if (loadedIds.has(altId)) continue;
+              // Also check by trial name — handles case where scenario folder name
+              // differs from scenario.md frontmatter name (e.g., folder "subagent-test"
+              // but name: "sa-test" in frontmatter)
+              if (loadedTrialNames.has(trialName)) continue;
 
               const scenarioPath = resolveScenarioPath(scenarioName);
               const agentMatch = agentSetups.find(a => a.name === agentName);

--- a/agent-benchmark/dashboard/src/types.ts
+++ b/agent-benchmark/dashboard/src/types.ts
@@ -34,6 +34,11 @@ export interface RunEntry {
   outputTokens?: string;
   cachedTokens?: string;
   tokenDisplay?: string; // Rich real-time display: "out: 37.8k (main: 35k, subs: 2.8k)"
+  premiumRequests?: number;
+  subAgentInputTokens?: string;   // sum of sub-agent inputTokens from session.shutdown
+  subAgentCachedTokens?: string;  // sum of sub-agent cacheReadTokens from session.shutdown
+  subAgentCount?: number;         // number of sub-agents spawned
+  subAgentDetails?: Array<{ name: string; totalTokens: number; durationMs: number }>;
   failReason?: string;
   currentOutput: string;
   startedAt?: Date;

--- a/agent-benchmark/dashboard/src/views/charts.tsx
+++ b/agent-benchmark/dashboard/src/views/charts.tsx
@@ -28,7 +28,7 @@ export function ChartsView({ entries }: Props) {
         TOKEN USAGE vs SCORE{aggregated.some(a => a.iterations > 1) ? " (averaged)" : ""}
       </Text>
       <Text color="gray" dimColor>
-        Each ● is a condition — further right and lower is better (high score, low tokens)
+        Each ● is an agent setup — further right and lower is better (high score, low tokens)
       </Text>
 
       {scenarios.map((scenario) => {

--- a/agent-benchmark/dashboard/src/views/progress.tsx
+++ b/agent-benchmark/dashboard/src/views/progress.tsx
@@ -156,7 +156,7 @@ function getStatusDisplay(entry: RunEntry): { text: string; color: string } {
     case "setup": return { text: `🔧 Setup... ${runElapsed(entry)}`, color: "cyan" };
     case "building": {
       const tokens = entry.tokenDisplay || (entry.outputTokens ? entry.outputTokens + " out" : "");
-      return { text: `🔄 Building... ${runElapsed(entry)}${tokens ? " [" + tokens + "]" : ""}`, color: "cyan" };
+      return { text: `🔄 Coding... ${runElapsed(entry)}${tokens ? " [" + tokens + "]" : ""}`, color: "cyan" };
     }
     case "build_done": return { text: `📦 Built ${runElapsed(entry)}`, color: "cyan" };
     case "dotnet_build": return { text: `🔨 Compiling... ${runElapsed(entry)}`, color: "cyan" };
@@ -174,7 +174,7 @@ function getStatusDisplay(entry: RunEntry): { text: string; color: string } {
         ? formatElapsed(entry.finishedAt.getTime() - entry.startedAt.getTime())
         : "—");
       const tokens = entry.inputTokens || "";
-      const subTok = entry.subAgentInputTokens ? `+${entry.subAgentInputTokens}` : "";
+      const subTok = entry.subAgentInputTokens ? ` (sub:${entry.subAgentInputTokens})` : "";
       const pr = entry.premiumRequests ? `, ${entry.premiumRequests} premium` : "";
       return { text: `${grade.letter} ${score} (${time}${tokens ? ", " + tokens + subTok : ""}${pr})`, color: grade.color };
     }

--- a/agent-benchmark/dashboard/src/views/progress.tsx
+++ b/agent-benchmark/dashboard/src/views/progress.tsx
@@ -120,7 +120,7 @@ export function ProgressView({ entries, runName, elapsed, isRunning, onRerun, on
       </Box>
       <Box flexDirection="column" marginTop={1}>
         <Text color="gray">
-          {"  "}{pad("Scenario", 22)} {pad("Condition", 32)} {pad("Model", 12)} Status
+          {"  "}{pad("Scenario", 22)} {pad("AgentSetup", 32)} {pad("Model", 12)} Status
         </Text>
         <Text color="gray">
           {"  "}{"─".repeat(100)}
@@ -174,7 +174,9 @@ function getStatusDisplay(entry: RunEntry): { text: string; color: string } {
         ? formatElapsed(entry.finishedAt.getTime() - entry.startedAt.getTime())
         : "—");
       const tokens = entry.inputTokens || "";
-      return { text: `${grade.letter} ${score} (${time}${tokens ? ", " + tokens : ""})`, color: grade.color };
+      const subTok = entry.subAgentInputTokens ? `+${entry.subAgentInputTokens}` : "";
+      const pr = entry.premiumRequests ? `, ${entry.premiumRequests} premium` : "";
+      return { text: `${grade.letter} ${score} (${time}${tokens ? ", " + tokens + subTok : ""}${pr})`, color: grade.color };
     }
     case "failed": {
       const time = entry.sessionTime || runElapsed(entry);

--- a/agent-benchmark/dashboard/src/views/results.tsx
+++ b/agent-benchmark/dashboard/src/views/results.tsx
@@ -5,6 +5,7 @@ import { join } from "path";
 import type { RunEntry } from "../types.js";
 import { aggregateEntries } from "../runner/aggregate.js";
 import { getGrade } from "../components/grades.js";
+import { parseTokenString } from "../components/scatter-plot.js";
 
 interface SummaryData {
   rankings?: Array<{ condition: string; avg_score: number; avg_time_minutes: number; summary: string }>;
@@ -47,9 +48,9 @@ export function ResultsView({ entries, runDir, cursorIndex = 0, onCursorClamp }:
       </Box>
       <Box flexDirection="column" marginTop={1}>
         <Text color="gray">
-          {"  "}{pad("Scenario", 26)} {pad("Condition", 22)} {pad("Model", 12)} {pad("Grade", 6)} {pad("Score", 10)} {pad("Time", 10)} {pad("Tokens", 8)} {pad("Price", 8)} {pad("Build", 6)} {pad("Run", 5)}
+          {"  "}{pad("Scenario", 26)} {pad("AgentSetup", 22)} {pad("Model", 12)} {pad("Grade", 6)} {pad("Score", 10)} {pad("Time", 10)} {pad("Tokens (main+subs)", 20)} {pad("Cached Tokens", 18)} {pad("Price", 8)} {pad("PremiumReq", 11)} {pad("Build", 6)} {pad("Run", 5)}
         </Text>
-        <Text color="gray">{"  "}{"─".repeat(118)}</Text>
+        <Text color="gray">{"  "}{"─".repeat(153)}</Text>
         {aggregated.map((agg, i) => {
           const shortModel = agg.model.replace("claude-", "");
           const scoreStr = agg.iterations > 1
@@ -58,17 +59,58 @@ export function ResultsView({ entries, runDir, cursorIndex = 0, onCursorClamp }:
           const grade = getGrade(agg.avgScore);
           const buildRate = `${Math.round(agg.buildRate * 100)}%`;
           const runRate = `${Math.round(agg.runRate * 100)}%`;
-          const tokens = agg.avgInputTokens || "—";
+
+          // Tokens: main + subs
+          const mainTok = agg.avgInputTokens || "—";
+          const subTok = agg.avgSubAgentInputTokens;
+          const tokensStr = subTok ? `${mainTok} + ${subTok}` : mainTok;
+
+          // Cached: main cached (%) + sub cached (%)
+          const mainCachedNum = parseTokenString(agg.avgCachedTokens || "0");
+          const mainInputNum = parseTokenString(agg.avgInputTokens || "0");
+          const mainCacheStr = mainInputNum > 0 && mainCachedNum > 0
+            ? `${agg.avgCachedTokens} (${(mainCachedNum / mainInputNum * 100).toFixed(2)}%)`
+            : "—";
+
+          // Sub-agent numbers for detail row
+          const subInputNum = parseTokenString(agg.avgSubAgentInputTokens || "0");
+          const subCachedNum = parseTokenString(agg.avgSubAgentCachedTokens || "0");
+
           const price = agg.avgPrice?.formatted || "—";
           const time = agg.avgSessionTime || "—";
+          const pr = agg.avgPremiumRequests != null ? String(agg.avgPremiumRequests) : "—";
 
           const isCursor = i === cursor;
           const prefix = isCursor ? "▶ " : "  ";
 
           return (
-            <Text key={i} color={grade.color} bold={isCursor}>
-              {prefix}{pad(agg.scenario, 26)} {pad(agg.condition, 22)} {pad(shortModel, 12)} {pad(grade.letter, 6)} {pad(scoreStr, 10)} {pad(time, 10)} {pad(tokens, 8)} {pad(price, 8)} {pad(buildRate, 6)} {pad(runRate, 5)}
-            </Text>
+            <Box key={i} flexDirection="column">
+              <Text color={grade.color} bold={isCursor}>
+                {prefix}{pad(agg.scenario, 26)} {pad(agg.condition, 22)} {pad(shortModel, 12)} {pad(grade.letter, 6)} {pad(scoreStr, 10)} {pad(time, 10)} {pad(tokensStr, 20)} {pad(mainCacheStr, 18)} {pad(price, 8)} {pad(pr, 11)} {pad(buildRate, 6)} {pad(runRate, 5)}
+              </Text>
+              {isCursor && (
+                <Box flexDirection="column">
+                  <Text color="gray">
+                    {"     "}↳ Main: {mainTok} in, {agg.avgCachedTokens || "0"} cached ({mainInputNum > 0 ? (mainCachedNum / mainInputNum * 100).toFixed(1) : "0"}%)
+                    {subInputNum > 0
+                      ? `  |  Sub agents (${agg.avgSubAgentCount || 0}): ${agg.avgSubAgentInputTokens} total${subCachedNum > 0 ? `, ${agg.avgSubAgentCachedTokens} cached (${(subCachedNum / subInputNum * 100).toFixed(1)}%)` : ""}`
+                      : "  |  Sub agents: none"
+                    }
+                    {`  |  Premium requests count: ${pr}`}
+                  </Text>
+                  {(() => {
+                    // Show per-sub-agent details from first entry in the group
+                    const details = agg.entries[0]?.subAgentDetails;
+                    if (!details || details.length === 0) return null;
+                    return details.map((sub, j) => (
+                      <Text key={j} color="gray">
+                        {"       "}- {sub.name}: {sub.totalTokens >= 1000 ? `${(sub.totalTokens / 1000).toFixed(1)}k` : sub.totalTokens} tokens, {sub.durationMs >= 60000 ? `${(sub.durationMs / 60000).toFixed(1)}m` : `${(sub.durationMs / 1000).toFixed(0)}s`}
+                      </Text>
+                    ));
+                  })()}
+                </Box>
+              )}
+            </Box>
           );
         })}
       </Box>

--- a/agent-benchmark/dashboard/src/views/results.tsx
+++ b/agent-benchmark/dashboard/src/views/results.tsx
@@ -48,7 +48,7 @@ export function ResultsView({ entries, runDir, cursorIndex = 0, onCursorClamp }:
       </Box>
       <Box flexDirection="column" marginTop={1}>
         <Text color="gray">
-          {"  "}{pad("Scenario", 26)} {pad("AgentSetup", 22)} {pad("Model", 12)} {pad("Grade", 6)} {pad("Score", 10)} {pad("Time", 10)} {pad("Tokens (main+subs)", 20)} {pad("Cached Tokens", 18)} {pad("Price", 8)} {pad("PremiumReq", 11)} {pad("Build", 6)} {pad("Run", 5)}
+          {"  "}{pad("Scenario", 18)} {pad("AgentSetup", 30)} {pad("Model", 12)} {pad("Grade", 6)} {pad("Score", 10)} {pad("Time", 10)} {pad("Tokens (main + subs)", 20)} {pad("Cached Tokens", 18)} {pad("Price", 8)} {pad("PremiumReq", 11)} {pad("Build", 6)} {pad("Run", 5)}
         </Text>
         <Text color="gray">{"  "}{"─".repeat(153)}</Text>
         {aggregated.map((agg, i) => {
@@ -60,20 +60,22 @@ export function ResultsView({ entries, runDir, cursorIndex = 0, onCursorClamp }:
           const buildRate = `${Math.round(agg.buildRate * 100)}%`;
           const runRate = `${Math.round(agg.runRate * 100)}%`;
 
-          // Tokens: main + subs
+          // Tokens: total (main + sub breakdown)
           const mainTok = agg.avgInputTokens || "—";
           const subTok = agg.avgSubAgentInputTokens;
-          const tokensStr = subTok ? `${mainTok} + ${subTok}` : mainTok;
-
-          // Cached: main cached (%) + sub cached (%)
-          const mainCachedNum = parseTokenString(agg.avgCachedTokens || "0");
           const mainInputNum = parseTokenString(agg.avgInputTokens || "0");
+          const subInputNum = parseTokenString(agg.avgSubAgentInputTokens || "0");
+          const mainOnlyNum = mainInputNum - subInputNum;
+          const tokensStr = subInputNum > 0
+            ? `${mainTok} (${formatTok(mainOnlyNum)}+${subTok})`
+            : mainTok;
+
+          // Cached: total cached (%)
+          const mainCachedNum = parseTokenString(agg.avgCachedTokens || "0");
           const mainCacheStr = mainInputNum > 0 && mainCachedNum > 0
             ? `${agg.avgCachedTokens} (${(mainCachedNum / mainInputNum * 100).toFixed(2)}%)`
             : "—";
 
-          // Sub-agent numbers for detail row
-          const subInputNum = parseTokenString(agg.avgSubAgentInputTokens || "0");
           const subCachedNum = parseTokenString(agg.avgSubAgentCachedTokens || "0");
 
           const price = agg.avgPrice?.formatted || "—";
@@ -86,25 +88,27 @@ export function ResultsView({ entries, runDir, cursorIndex = 0, onCursorClamp }:
           return (
             <Box key={i} flexDirection="column">
               <Text color={grade.color} bold={isCursor}>
-                {prefix}{pad(agg.scenario, 26)} {pad(agg.condition, 22)} {pad(shortModel, 12)} {pad(grade.letter, 6)} {pad(scoreStr, 10)} {pad(time, 10)} {pad(tokensStr, 20)} {pad(mainCacheStr, 18)} {pad(price, 8)} {pad(pr, 11)} {pad(buildRate, 6)} {pad(runRate, 5)}
+                {prefix}{pad(agg.scenario, 18)} {pad(agg.condition, 30)} {pad(shortModel, 12)} {pad(grade.letter, 6)} {pad(scoreStr, 10)} {pad(time, 10)} {pad(tokensStr, 20)} {pad(mainCacheStr, 18)} {pad(price, 8)} {pad(pr, 11)} {pad(buildRate, 6)} {pad(runRate, 5)}
               </Text>
               {isCursor && (
                 <Box flexDirection="column">
                   <Text color="gray">
-                    {"     "}↳ Main: {mainTok} in, {agg.avgCachedTokens || "0"} cached ({mainInputNum > 0 ? (mainCachedNum / mainInputNum * 100).toFixed(1) : "0"}%)
-                    {subInputNum > 0
-                      ? `  |  Sub agents (${agg.avgSubAgentCount || 0}): ${agg.avgSubAgentInputTokens} total${subCachedNum > 0 ? `, ${agg.avgSubAgentCachedTokens} cached (${(subCachedNum / subInputNum * 100).toFixed(1)}%)` : ""}`
-                      : "  |  Sub agents: none"
-                    }
+                    {"     "}↳ Total tokens: {mainTok}
+                    {`  |  Cached: ${agg.avgCachedTokens || "0"} (${mainInputNum > 0 ? (mainCachedNum / mainInputNum * 100).toFixed(1) : "0"}%)`}
+                    {`  |  Non-cached: ${mainInputNum > 0 ? formatTok(mainInputNum - mainCachedNum) : "0"} (${mainInputNum > 0 ? ((1 - mainCachedNum / mainInputNum) * 100).toFixed(1) : "0"}%)`}
                     {`  |  Premium requests count: ${pr}`}
                   </Text>
+                  {subInputNum > 0 && (
+                    <Text color="gray">
+                      {"       "}| Sub agents ({agg.avgSubAgentCount || 0}): {agg.avgSubAgentInputTokens}
+                    </Text>
+                  )}
                   {(() => {
-                    // Show per-sub-agent details from first entry in the group
                     const details = agg.entries[0]?.subAgentDetails;
                     if (!details || details.length === 0) return null;
                     return details.map((sub, j) => (
                       <Text key={j} color="gray">
-                        {"       "}- {sub.name}: {sub.totalTokens >= 1000 ? `${(sub.totalTokens / 1000).toFixed(1)}k` : sub.totalTokens} tokens, {sub.durationMs >= 60000 ? `${(sub.durationMs / 60000).toFixed(1)}m` : `${(sub.durationMs / 1000).toFixed(0)}s`}
+                        {"       "}- {sub.name}: {sub.totalTokens >= 1000 ? `${(sub.totalTokens / 1000).toFixed(1)}k` : sub.totalTokens} tokens, {sub.durationMs >= 60000 ? `${Math.floor(sub.durationMs / 60000)}min ${Math.floor((sub.durationMs % 60000) / 1000)}s` : `${Math.floor(sub.durationMs / 1000)}s`}
                       </Text>
                     ));
                   })()}
@@ -168,4 +172,10 @@ function SummarySection({ runDir }: { runDir?: string }) {
 
 function pad(s: string, len: number): string {
   return s.length >= len ? s.slice(0, len) : s + " ".repeat(len - s.length);
+}
+
+function formatTok(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}m`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(Math.round(n));
 }

--- a/agent-benchmark/dashboard/src/views/summary.tsx
+++ b/agent-benchmark/dashboard/src/views/summary.tsx
@@ -66,7 +66,7 @@ export function SummaryView({ entries, runDir }: Props) {
       <Box flexDirection="column" marginTop={1} paddingX={1} flexShrink={0}>
         <Text bold color="white">Quick Stats</Text>
         <Text color="gray">
-          {"  "}Conditions tested: {[...new Set(aggregated.map((a) => a.condition))].length}
+          {"  "}Agent setups tested: {[...new Set(aggregated.map((a) => a.condition))].length}
         </Text>
         <Text color="gray">
           {"  "}Scenarios: {[...new Set(aggregated.map((a) => a.scenario))].join(", ")}
@@ -76,6 +76,9 @@ export function SummaryView({ entries, runDir }: Props) {
         </Text>
         <Text color="gray">
           {"  "}Total runs: {entries.length} ({entries.filter((e) => e.status === "done").length} passed, {entries.filter((e) => e.status === "failed").length} failed, {entries.filter((e) => e.status === "timeout").length} timeout)
+        </Text>
+        <Text color="gray">
+          {"  "}Total premium requests: {entries.reduce((sum, e) => sum + (e.premiumRequests ?? 0), 0)}
         </Text>
       </Box>
 
@@ -90,7 +93,7 @@ export function SummaryView({ entries, runDir }: Props) {
               : `${agg.avgScore}/100`;
           return (
             <Text key={i} color={grade.color}>
-              {"  "}{i + 1}. {pad(grade.letter, 4)} {pad(agg.condition, 28)} {pad(agg.model.replace("claude-", ""), 12)} {pad(scoreRange, 20)} {pad(agg.avgInputTokens || "—", 8)} {pad(agg.avgPrice?.formatted || "—", 8)}
+              {"  "}{i + 1}. {pad(grade.letter, 4)} {pad(agg.condition, 28)} {pad(agg.model.replace("claude-", ""), 12)} {pad(scoreRange, 20)} {pad(agg.avgInputTokens || "\u2014", 8)} {pad(agg.avgPrice?.formatted || "\u2014", 8)} {pad(agg.avgPremiumRequests != null ? `${agg.avgPremiumRequests} premium` : "\u2014", 12)}
             </Text>
           );
         })}


### PR DESCRIPTION
### Description

This PR
1. adds data of cached/non-cached token cost, 
2. count premium requests,
3. list the token cost and time cost of each subagent process

### Implementation

Given the data of cahced token only exists in copilot's config dir and can't re-ouput to a specified jsonl log file, we are resetting "--config-dir" to a log dir under the work folder and getting logged data from there.

### Demo

Screen shot about what's being added:
<img width="1268" height="237" alt="image" src="https://github.com/user-attachments/assets/df1eaa17-fa70-4cb7-885c-e2d993d839da" />

<img width="1268" height="237" alt="image" src="https://github.com/user-attachments/assets/d2cc3144-85ce-4d4c-94fb-2404f06faa15" />

