### PR TITLE
Add Codex plugin support

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "microsoft-winui",
+  "interface": {
+    "displayName": "Microsoft WinUI"
+  },
+  "plugins": [
+    {
+      "name": "winui",
+      "source": {
+        "source": "local",
+        "path": "./plugins/winui"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WinUI agents and skills for Windows app development
 
-A Github Copilot and Claude Code plugin for building native Windows apps with **WinUI 3** and the **Windows App SDK** to cover the end-to-end inner loop: scaffold → design → build → run → test → package → ship.
+A GitHub Copilot, Claude Code, and OpenAI Codex plugin for building native Windows apps with **WinUI 3** and the **Windows App SDK** to cover the end-to-end inner loop: scaffold → design → build → run → test → package → ship.
 
 <img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/b7d25afc-ba15-4d8a-8dcf-2dd78000f3aa" />
 
@@ -10,7 +10,7 @@ A Github Copilot and Claude Code plugin for building native Windows apps with **
 
 ## Install
 
-The plugin requires **GitHub Copilot** (`winget install GitHub.Copilot`) or **Claude Code** installed. 
+The plugin requires **GitHub Copilot** (`winget install GitHub.Copilot`), **Claude Code**, or **OpenAI Codex** installed. 
 
 **Git** (`winget install Git.Git`) is required for installing pluggins.
 
@@ -45,7 +45,15 @@ claude plugin marketplace add microsoft/win-dev-skills
 claude plugin install winui@win-dev-skills
 ```
 
+For **OpenAI Codex**, add the marketplace and then enable the `winui` plugin from the plugin directory (Codex doesn't currently expose a CLI install command):
+
+```powershell
+codex plugin marketplace add microsoft/win-dev-skills
+```
+
 Then start a new session and run the `winui-setup` skill with `/winui-setup`.
+
+> **Note on Codex:** Codex doesn't have an "agents" concept, so the orchestrator agent isn't exposed there. The skills still work — invoke them by name (e.g. `/winui-setup`, `/winui-design`) and Codex will load them on demand.
 
 Once setup is done, try a real task:
 
@@ -55,6 +63,12 @@ copilot --agent winui:winui-dev -p "Build me a WinUI 3 markdown editor with live
 
 ```sh
 claude --agent winui:winui-dev -p "Build me a WinUI 3 markdown editor with live preview and a custom title bar"
+```
+
+For Codex, run `codex` and ask it directly:
+
+```
+Build me a WinUI 3 markdown editor with live preview and a custom title bar.
 ```
 
 ### What gets installed

--- a/README.md
+++ b/README.md
@@ -33,43 +33,47 @@ Install the Copilot CLI plugin "winui" from microsoft/win-dev-skills, then set u
 
 ### Option B — Install the plugin yourself, then ask the agent to set up the rest
 
-If you'd rather run the plugin commands by hand, the same commands work for **GitHub Copilot CLI** and **Claude Code** — just swap `copilot` for `claude` (or vice versa):
+If you'd rather run the plugin commands by hand:
+
+<details>
+<summary><strong>GitHub Copilot CLI</strong></summary>
+
+The plugin is listed on **awesome-copilot** and can be installed directly:
+
+```powershell
+copilot plugin install winui@awesome-copilot
+```
+
+Or add this repo as a marketplace and install from there:
 
 ```powershell
 copilot plugin marketplace add microsoft/win-dev-skills
 copilot plugin install winui@win-dev-skills
 ```
+</details>
+
+<details>
+<summary><strong>Claude Code</strong></summary>
 
 ```powershell
 claude plugin marketplace add microsoft/win-dev-skills
 claude plugin install winui@win-dev-skills
 ```
+</details>
 
-For **OpenAI Codex**, add the marketplace and then enable the `winui` plugin from the plugin directory (Codex doesn't currently expose a CLI install command):
+<details>
+<summary><strong>OpenAI Codex</strong></summary>
 
-```powershell
-codex plugin marketplace add microsoft/win-dev-skills
-```
+Add the `microsoft/win-dev-skills` marketplace, then enable the `winui` plugin from the plugin directory.
+
+> **Note:** Codex doesn't have an "agents" concept, so the orchestrator agent isn't exposed there. The skills still work - invoke them by name (e.g. `/winui-setup`, `/winui-design`) and Codex will load them on demand.
+</details>
 
 Then start a new session and run the `winui-setup` skill with `/winui-setup`.
 
-> **Note on Codex:** Codex doesn't have an "agents" concept, so the orchestrator agent isn't exposed there. The skills still work — invoke them by name (e.g. `/winui-setup`, `/winui-design`) and Codex will load them on demand.
-
 Once setup is done, try a real task:
 
-```sh
-copilot --agent winui:winui-dev -p "Build me a WinUI 3 markdown editor with live preview and a custom title bar"
-```
-
-```sh
-claude --agent winui:winui-dev -p "Build me a WinUI 3 markdown editor with live preview and a custom title bar"
-```
-
-For Codex, run `codex` and ask it directly:
-
-```
-Build me a WinUI 3 markdown editor with live preview and a custom title bar.
-```
+> "Build me a WinUI 3 markdown editor with live preview and a custom title bar"
 
 ### What gets installed
 

--- a/plugins/winui/.codex-plugin/plugin.json
+++ b/plugins/winui/.codex-plugin/plugin.json
@@ -1,0 +1,45 @@
+{
+  "name": "winui",
+  "version": "0.3.0",
+  "description": "Agents and skills for WinUI 3 app development. Create new WinUI 3 desktop apps, convert from other frameworks to WinUI 3, or add features to existing WinUI 3 applications.",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://github.com/microsoft/win-dev-skills"
+  },
+  "homepage": "https://aka.ms/winui-skills",
+  "repository": "https://github.com/microsoft/win-dev-skills",
+  "license": "MIT",
+  "keywords": [
+    "windows",
+    "winui",
+    "winui3",
+    "xaml",
+    "windows app sdk",
+    "msix",
+    "packaging",
+    "code signing",
+    "microsoft store",
+    "wpf",
+    "dotnet",
+    "desktop app",
+    "fluent design",
+    "accessibility"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "WinUI",
+    "shortDescription": "Build, package, and ship WinUI 3 desktop apps.",
+    "longDescription": "End-to-end WinUI 3 development for AI agents — scaffold projects, design XAML with Fluent UI and accessibility, build and diagnose with a real toolchain, automate UI tests, run code reviews, migrate from WPF, and package signed MSIX installers. Each skill is paired with purpose-built tools so the agent fetches just what it needs.",
+    "developerName": "Microsoft",
+    "category": "Developer Tools",
+    "capabilities": ["Read", "Write"],
+    "websiteURL": "https://aka.ms/winui-skills",
+    "defaultPrompt": [
+      "Create a new WinUI 3 app with MVVM.",
+      "Build and run the WinUI 3 project in this folder and fix any errors.",
+      "Migrate this WPF app to WinUI 3.",
+      "Package this WinUI 3 app as a signed MSIX."
+    ],
+    "brandColor": "#1f7fd6"
+  }
+}


### PR DESCRIPTION
Adds OpenAI Codex platform support alongside the existing Copilot CLI and Claude Code manifests.

## Changes

- **`plugins/winui/.codex-plugin/plugin.json`** — Codex manifest with `interface` block (displayName, shortDescription, longDescription, category, capabilities, defaultPrompt, brandColor). Points `skills: ./skills/` to reuse all 8 existing skills unchanged.
- **`.agents/plugins/marketplace.json`** — repo-level marketplace catalog so users can run:
  ```
  codex plugin marketplace add microsoft/win-dev-skills
  ```

## Compatibility notes

- All 8 `SKILL.md` files use the standard `name`/`description` frontmatter that Codex expects — no skill changes needed.
- Codex has no `agents` concept, so `winui-dev.agent.md` is not exposed there. Follow-up: consider promoting it to a top-level skill.
- The existing Copilot CLI `plugin.json` and Claude Code `.claude-plugin/plugin.json` are untouched.

## Testing

Not yet verified against a live Codex install — OpenAI's self-serve marketplace is still "coming soon" per their docs. Manifest schema follows https://developers.openai.com/codex/plugins/build.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>