### PR TITLE
Add OpenCode support for WinUI skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,14 @@ The `version-bump` and `changelog-entry` CI jobs enforce this.
 
 ### Added
 
+- `winui-*` skills can now be discovered by **OpenCode** by linking the shared
+  `plugins/winui/skills/` directory into an OpenCode skills directory - no skill
+  fork or copy required.
+
 ### Changed
+
+- `winui-setup` now gives harness-neutral post-setup guidance while preserving the
+  GitHub Copilot CLI invocation example.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,6 @@ The `version-bump` and `changelog-entry` CI jobs enforce this.
 
 ### Added
 
-- `winui-*` skills can now be discovered by **OpenCode** by linking the shared
-  `plugins/winui/skills/` directory into an OpenCode skills directory - no skill
-  fork or copy required.
-
 ### Changed
 
 - `winui-setup` now gives harness-neutral post-setup guidance while preserving the

--- a/README.md
+++ b/README.md
@@ -91,6 +91,34 @@ Verify the eight skills loaded with `openclaw skills list` (each shows `✓ read
 > **Note:** OpenClaw maps skills, not agents, so the `winui-dev` orchestrator agent isn't exposed there. The skills still work - ask the agent for a WinUI task and it loads the relevant skill on demand.
 </details>
 
+<details>
+<summary><strong>OpenCode</strong></summary>
+
+OpenCode loads Agent Skills natively from `<name>/SKILL.md` folders. Point it at the
+shared skills - no fork or copy needed. Link each skill into OpenCode's global skills
+directory (or a project's `.opencode/skills/`):
+
+```powershell
+# One-time setup: link the shared skills into OpenCode's global skills directory
+$src = "C:\path\to\win-dev-skills\plugins\winui\skills"
+$dst = "$env:USERPROFILE\.config\opencode\skills"
+New-Item -ItemType Directory -Force $dst | Out-Null
+Get-ChildItem $src -Directory | ForEach-Object {
+  $link = Join-Path $dst $_.Name
+  if (-not (Test-Path $link)) {
+    New-Item -ItemType Junction -Path $link -Target $_.FullName | Out-Null
+  }
+}
+```
+
+Because these are junctions (not copies), `git pull` in the repo picks up upstream
+skill updates automatically.
+
+> **Note:** OpenCode maps skills, not agents, so the `winui-dev` orchestrator agent
+> isn't exposed there. The skills still work - invoke them by name (e.g. `/winui-setup`,
+> `/winui-design`) and OpenCode loads them on demand.
+</details>
+
 Then start a new session and run the `winui-setup` skill with `/winui-setup`.
 
 Once setup is done, try a real task:

--- a/plugins/winui/skills/winui-setup/SKILL.md
+++ b/plugins/winui/skills/winui-setup/SKILL.md
@@ -130,15 +130,21 @@ After everything, print a single-table summary so the user knows exactly what ch
 WinApp CLI                 ✅ upgraded to 0.4.0  (or ✅ installed, ⏭ already at latest, ❌ failed)
 WinUI 3 templates          ✅ updated to latest
 Developer Mode             ✅ enabled  (or ⏭ skipped — user declined, or ❌ failed: <reason>)
-
-You're ready. Try:
-  copilot --agent winui:winui-dev -p "build me a WinUI 3 markdown editor"
 ```
+
+You're ready. If the current harness exposes the `winui-dev` orchestrator agent,
+start a fresh session with that agent and ask it to build a WinUI app. Otherwise,
+start a fresh session in the current harness and ask it to perform the WinUI task;
+it will load the relevant `winui-*` skills on demand.
+
+For GitHub Copilot CLI, for example:
+
+    copilot --agent winui:winui-dev -p "build me a WinUI 3 markdown editor"
 
 ### Things to NOT do
 
 - ❌ **Do not install Visual Studio.** It is not required — these skills build and run with the dotnet and winapp clis.
-- ❌ **Do not install GitHub Copilot CLI.** If this skill is running, it's already installed.
+- ❌ **Do not install or upgrade the user's AI coding harness** as part of this skill. `winui-setup` manages Windows/WinUI development prerequisites only.
 - ❌ **Do not elevate the entire session** — only step 5 needs admin. Elevating earlier steps would install winget packages into the admin user's profile instead of the user's, which is wrong.
 - ❌ **Do not skip the PATH refresh** — agents that skip it install the SDK and then immediately fail on `dotnet new install`.
 - ❌ **Do not trigger UAC for Developer Mode without asking the user first** — the prompt is jarring if it pops up unannounced. Always confirm before elevating.


### PR DESCRIPTION
<!--
Base branch: this PR should target `staging`, not `main`.
PRs to `main` are reserved for the promotion PR (cut by maintainers from
`staging`) and `hotfix/*` branches. See CONTRIBUTING.md for the flow.
The `pr-target-policy` CI check enforces this.
-->

## Description

<!-- Briefly describe what this PR does and why -->

OpenCode loads Agent Skills natively from `<name>/SKILL.md` folders, but there was no guidance for pointing it at the shared `plugins/winui/skills/` directory. This PR documents a one-time junction-based setup so OpenCode users consume the same skills (no fork or copy), and makes `winui-setup`'s post-setup guidance harness-neutral while keeping the GitHub Copilot CLI example. No skills are forked or copied, and no existing harness manifests, agents, or parsers change.

## Related Issue

<!-- Link to any related issues: Fixes #123, Closes #456, Related to #789 -->

Part of #149

## Type of Change

<!-- Keep the applicable line(s), delete the rest -->

- ✨ New skill or feature
- 📝 Documentation

## Affected area

<!-- Check all that apply -->

- [ ] Agent (`plugins/winui/agents/`)
- [x] Skill: <!-- name(s) --> winui-setup
- [ ] Tool: <!-- winui-analyzer / winui-search / winmd-cli -->
- [ ] Plugin metadata (`plugin.json`, `plugins/winui/`)
- [x] Repo-level docs / governance

## Checklist

<!-- Delete the ones that do not apply -->

- [x] Tested locally on Windows (build + agent invocation if applicable)
- [x] If a skill changed: `SKILL.md` frontmatter still valid; cross-references to other skills still resolve
- [x] If user-facing: added a bullet to `## [Unreleased]` in `CHANGELOG.md`
- [x] Did **not** edit any `version` field in `plugins/winui/plugin.json`, `.github/plugin/marketplace.json`, or `.claude-plugin/marketplace.json` (versions bump only on the `staging → main` promotion PR — see [`RELEASING.md`](../RELEASING.md))

## Screenshots / Demo

<!-- If applicable, add screenshots, agent transcript snippets, or GIFs demonstrating the changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

Base branch is `staging`.

## AI Description

<!-- ai-description-start -->
_This section is auto-generated by AI when the PR is opened or updated. To opt out, delete this entire section including the marker comments._
<!-- ai-description-end -->