### PR TITLE
Add OpenCode winui-dev orchestrator agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The `version-bump` and `changelog-entry` CI jobs enforce this.
 
 ### Added
 
+- Added an OpenCode `winui-dev` orchestrator agent (`plugins/winui/opencode/agent/winui-dev.md`) that loads `winui-dev-workflow` and `winui-design` on demand, so OpenCode users can run `opencode run --agent winui-dev` for end-to-end WinUI 3 builds.
+
 ### Changed
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -91,6 +91,47 @@ Verify the eight skills loaded with `openclaw skills list` (each shows `✓ read
 > **Note:** OpenClaw maps skills, not agents, so the `winui-dev` orchestrator agent isn't exposed there. The skills still work - ask the agent for a WinUI task and it loads the relevant skill on demand.
 </details>
 
+<details>
+<summary><strong>OpenCode</strong></summary>
+
+OpenCode ships a `winui-dev` orchestrator agent that loads the shared skills and
+does the WinUI 3 build work end to end. Link the agent and the skills it depends
+on into OpenCode's global config directory (no fork or copy needed):
+
+```powershell
+# One-time setup: link the agent + shared skills into OpenCode's global config
+$src = "C:\path\to\win-dev-skills\plugins\winui"
+$dst = "$env:USERPROFILE\.config\opencode"
+New-Item -ItemType Directory -Force "$dst\agent", "$dst\skills" | Out-Null
+
+# Shared skills (loaded on demand by the agent)
+Get-ChildItem "$src\skills" -Directory | ForEach-Object {
+  $link = Join-Path "$dst\skills" $_.Name
+  if (-not (Test-Path $link)) {
+    New-Item -ItemType Junction -Path $link -Target $_.FullName | Out-Null
+  }
+}
+
+# Orchestrator agent
+$agent = "$dst\agent\winui-dev.md"
+if (-not (Test-Path $agent)) {
+  New-Item -ItemType Junction -Path $agent -Target "$src\opencode\agent\winui-dev.md" | Out-Null
+}
+```
+
+Because these are junctions (not copies), `git pull` in the repo picks up upstream
+updates automatically. Then start OpenCode with the orchestrator:
+
+```powershell
+opencode run --agent winui-dev
+```
+
+The `winui-dev` agent loads `winui-dev-workflow` (build & run) and `winui-design`
+(Fluent Design, control selection, and `winui-search.exe` for grounded lookup) on
+demand, so there's no need to invoke the skills manually. The individual skills can
+also be invoked by name (e.g. `/winui-setup`) as usual.
+</details>
+
 Then start a new session and run the `winui-setup` skill with `/winui-setup`.
 
 Once setup is done, try a real task:

--- a/plugins/winui/opencode/agent/winui-dev.md
+++ b/plugins/winui/opencode/agent/winui-dev.md
@@ -1,0 +1,28 @@
+---
+description: "Builds WinUI 3 desktop applications using Windows App SDK, XAML, and C#. Use for creating new apps, adding features, converting from WPF/Electron/web, fixing bugs, or any WinUI 3 / WinAppSDK / XAML task."
+mode: all
+permission:
+  question: allow
+  plan_enter: allow
+---
+
+## You Are The WinUI Developer — Do The Work Yourself
+
+You are `winui-dev` — don't call `task` with `subagent_type: "winui-dev"` (self-hop). `task` is fine for scoped helpers (`explore` for parallel codebase mapping, `general` for rubber-duck critique), not for the build itself.
+
+## Process
+
+You build WinUI 3 desktop apps following this process: understand requirements → design and plan UI → scaffold if needed → write code → build & run. The user might ask you to use other steps defined by skills such as `winui-ui-testing` for UI validation or `winui-code-review` for quality checks if desired only.
+
+Before continuing
+
+1. Load the `winui-dev-workflow` skill with `/winui-dev-workflow` — it has `BuildAndRun.ps1` for building and running your app
+2. Load the `winui-design` skill with `/winui-design` — it has Fluent Design rules, control selection, XAML correctness, and theming guidance, **and it bundles `winui-search.exe` for grounded control lookup against the WinUI Gallery, Community Toolkit, and Reactor catalogue**
+
+## Best Practices
+
+- **Efficiency:** Batch file creates/edits in one pass. Don't re-read files you just wrote. Chain dependent commands with `&&`.
+- **ReadEfficiently:** Read files efficiently. Avoid reading the same file multiple times. Use caching or batch operations when possible.
+- **Principles:** YAGNI (no speculative abstractions), DRY (search before writing new code), KISS (simplest solution that works).
+- **Accessibility:** Set `AutomationProperties.AutomationId` on every interactive control (Button, TextBox, ComboBox, CheckBox, ToggleSwitch, NavigationViewItem). Use unique naming for each control.
+- **Code quality:** File-scoped namespaces, `_camelCase` private fields, PascalCase types/methods/properties, `Async` suffix on async methods, `Is/Has/Can` prefix on booleans.


### PR DESCRIPTION
<!--
Base branch: this PR should target `staging`, not `main`.
PRs to `main` are reserved for the promotion PR (cut by maintainers from
`staging`) and `hotfix/*` branches. See CONTRIBUTING.md for the flow.
The `pr-target-policy` CI check enforces this.
-->

## Description

<!-- Briefly describe what this PR does and why -->

Exposes the `winui-dev` orchestrator to OpenCode so OpenCode users get the same end-to-end WinUI 3 build flow as Copilot CLI (`opencode run --agent winui-dev`).

OpenCode loads custom agents from `<config-dir>/agent/*.md` markdown files (frontmatter metadata + body as the system prompt), so this adds a small adapter that mirrors the existing Copilot `plugins/winui/agents/winui-dev.agent.md`:

- `plugins/winui/opencode/agent/winui-dev.md` — a `mode: all` agent (selectable as primary, spawnable as subagent) with `question` and `plan_enter` permissioned `allow` to match OpenCode's native `build` agent, so it can drive interactive builds.
- Prompt adaptations: the self-hop guard uses `subagent_type` instead of `agent_type`, the `general-purpose` helper maps to OpenCode's `general` subagent, and skills load via `/winui-dev-workflow` and `/winui-design` slash commands.
- README documents the one-time agent + skills junction setup.

## Related Issue

<!-- Link to any related issues: Fixes #123, Closes #456, Related to #789 -->

Part of #149

## Type of Change

<!-- Keep the applicable line(s), delete the rest -->

- ✨ New skill or feature

## Affected area

<!-- Check all that apply -->

- [x] Agent (`plugins/winui/agents/`) (new OpenCode agent: `plugins/winui/opencode/agent/winui-dev.md`)
- [x] Repo-level docs / governance

## Checklist

<!-- Delete the ones that do not apply -->

- [x] Tested locally on Windows (build + agent invocation if applicable)
- [x] If a CLI command or agent invocation changed: `README.md` updated
- [x] If user-facing: added a bullet to `## [Unreleased]` in `CHANGELOG.md`
- [x] Did **not** edit any `version` field in `plugins/winui/plugin.json`, `.github/plugin/marketplace.json`, or `.claude-plugin/marketplace.json` (versions bump only on the `staging → main` promotion PR — see [`RELEASING.md`](../RELEASING.md))

## Screenshots / Demo

<!-- If applicable, add screenshots, agent transcript snippets, or GIFs demonstrating the changes -->

## Additional Notes

<!-- Any additional information that reviewers should know -->

## AI Description

<!-- ai-description-start -->
_This section is auto-generated by AI when the PR is opened or updated. To opt out, delete this entire section including the marker comments._
<!-- ai-description-end -->