### PR TITLE
Hotfix: sync Claude/Codex adapter manifest versions to 0.6.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,12 @@
     "url": "https://github.com/microsoft/win-dev-skills"
   },
   "description": "Agents and skills for native Windows app development with WinUI 3 and the Windows App SDK.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "plugins": [
     {
       "name": "winui",
       "description": "Agents and skills for WinUI 3 app development. Create new WinUI 3 desktop apps, convert from other frameworks to WinUI 3, or add features to existing WinUI 3 applications.",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "source": "./plugins/winui",
       "category": "windows-development",
       "tags": [

--- a/.github/plugin/marketplace.json
+++ b/.github/plugin/marketplace.json
@@ -6,13 +6,13 @@
   },
   "metadata": {
     "description": "Agents and skills for native Windows app development with WinUI 3 and the Windows App SDK.",
-    "version": "0.6.0"
+    "version": "0.6.1"
   },
   "plugins": [
     {
       "name": "winui",
       "description": "Agents and skills for WinUI 3 app development. Create new WinUI 3 desktop apps, convert from other frameworks to WinUI 3, or add features to existing WinUI 3 applications.",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "source": "./plugins/winui/agent-plugin"
     }
   ]

--- a/.github/workflows/release-policy.yml
+++ b/.github/workflows/release-policy.yml
@@ -90,6 +90,8 @@ jobs:
             "$(jq -r '.plugins[0].version' .github/plugin/marketplace.json)"
             "$(jq -r '.version' .claude-plugin/marketplace.json)"
             "$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)"
+            "$(jq -r '.version' plugins/winui/.claude-plugin/plugin.json)"
+            "$(jq -r '.version' plugins/winui/.codex-plugin/plugin.json)"
           )
           BASE_VERSIONS=(
             "$(read_base_plugin_version)"
@@ -97,6 +99,8 @@ jobs:
             "$(git show "$BASE_SHA":.github/plugin/marketplace.json | jq -r '.plugins[0].version')"
             "$(git show "$BASE_SHA":.claude-plugin/marketplace.json | jq -r '.version')"
             "$(git show "$BASE_SHA":.claude-plugin/marketplace.json | jq -r '.plugins[0].version')"
+            "$(git show "$BASE_SHA":plugins/winui/.claude-plugin/plugin.json | jq -r '.version')"
+            "$(git show "$BASE_SHA":plugins/winui/.codex-plugin/plugin.json | jq -r '.version')"
           )
           LABELS=(
             "portable plugin"
@@ -104,6 +108,8 @@ jobs:
             "GitHub marketplace plugin"
             "Claude marketplace"
             "Claude marketplace plugin"
+            "Claude adapter plugin"
+            "Codex adapter plugin"
           )
 
           FAILED=0
@@ -182,8 +188,10 @@ jobs:
           PR_GH_PLUGIN=$(jq -r '.plugins[0].version' .github/plugin/marketplace.json)
           PR_CLAUDE_TOP=$(jq -r '.version' .claude-plugin/marketplace.json)
           PR_CLAUDE_PLUGIN=$(jq -r '.plugins[0].version' .claude-plugin/marketplace.json)
+          PR_CLAUDE_ADAPTER=$(jq -r '.version' plugins/winui/.claude-plugin/plugin.json)
+          PR_CODEX_ADAPTER=$(jq -r '.version' plugins/winui/.codex-plugin/plugin.json)
 
-          # main-side versions: read all 5 and require they're already in sync
+          # main-side versions: read all 7 and require they're already in sync
           # (defends against a previously-bad release leaving main inconsistent).
           if git cat-file -e "$BASE_SHA:plugins/winui/agent-plugin/plugin.json" 2>/dev/null; then
             MAIN_PLUGIN=$(git show "$BASE_SHA":plugins/winui/agent-plugin/plugin.json | jq -r '.version')
@@ -196,25 +204,32 @@ jobs:
           MAIN_GH_PLUGIN=$(git show "$BASE_SHA":.github/plugin/marketplace.json | jq -r '.plugins[0].version')
           MAIN_CLAUDE_TOP=$(git show "$BASE_SHA":.claude-plugin/marketplace.json | jq -r '.version')
           MAIN_CLAUDE_PLUGIN=$(git show "$BASE_SHA":.claude-plugin/marketplace.json | jq -r '.plugins[0].version')
+          MAIN_CLAUDE_ADAPTER=$(git show "$BASE_SHA":plugins/winui/.claude-plugin/plugin.json | jq -r '.version')
+          MAIN_CODEX_ADAPTER=$(git show "$BASE_SHA":plugins/winui/.codex-plugin/plugin.json | jq -r '.version')
 
-          MAIN_ALL=("$MAIN_PLUGIN" "$MAIN_GH_META" "$MAIN_GH_PLUGIN" "$MAIN_CLAUDE_TOP" "$MAIN_CLAUDE_PLUGIN")
+          MAIN_ALL=("$MAIN_PLUGIN" "$MAIN_GH_META" "$MAIN_GH_PLUGIN" "$MAIN_CLAUDE_TOP" "$MAIN_CLAUDE_PLUGIN" "$MAIN_CLAUDE_ADAPTER" "$MAIN_CODEX_ADAPTER")
+          # Advisory only, intentionally non-fatal: Rule 1 below already forces
+          # every PR-head field into sync, so a corrective hotfix PR (which by
+          # definition targets an already-inconsistent main) must still be able
+          # to pass this job. Failing here would deadlock exactly the PR meant
+          # to fix the drift it detects.
           for v in "${MAIN_ALL[@]}"; do
             if [[ "$v" != "$MAIN_PLUGIN" ]]; then
-              echo "::error::main-side version fields are out of sync: ${MAIN_ALL[*]}"
-              echo "::error::A previous release left main in an inconsistent state. Fix all 5 fields in this PR before continuing."
+              echo "::warning::main-side version fields are out of sync: ${MAIN_ALL[*]}"
+              echo "::warning::main was left in an inconsistent state by a previous release. This PR's Rule 1 check (below) still requires all 7 PR-head fields to match, so merging this PR will fix it."
               break
             fi
           done
 
-          echo "PR head: plugin=$PR_PLUGIN  gh.meta=$PR_GH_META  gh.plugin=$PR_GH_PLUGIN  claude.top=$PR_CLAUDE_TOP  claude.plugin=$PR_CLAUDE_PLUGIN"
-          echo "main:    plugin=$MAIN_PLUGIN  gh.meta=$MAIN_GH_META  gh.plugin=$MAIN_GH_PLUGIN  claude.top=$MAIN_CLAUDE_TOP  claude.plugin=$MAIN_CLAUDE_PLUGIN"
+          echo "PR head: plugin=$PR_PLUGIN  gh.meta=$PR_GH_META  gh.plugin=$PR_GH_PLUGIN  claude.top=$PR_CLAUDE_TOP  claude.plugin=$PR_CLAUDE_PLUGIN  claude.adapter=$PR_CLAUDE_ADAPTER  codex.adapter=$PR_CODEX_ADAPTER"
+          echo "main:    plugin=$MAIN_PLUGIN  gh.meta=$MAIN_GH_META  gh.plugin=$MAIN_GH_PLUGIN  claude.top=$MAIN_CLAUDE_TOP  claude.plugin=$MAIN_CLAUDE_PLUGIN  claude.adapter=$MAIN_CLAUDE_ADAPTER  codex.adapter=$MAIN_CODEX_ADAPTER"
 
-          # Rule 1: all 5 PR-head versions identical.
-          ALL=("$PR_PLUGIN" "$PR_GH_META" "$PR_GH_PLUGIN" "$PR_CLAUDE_TOP" "$PR_CLAUDE_PLUGIN")
+          # Rule 1: all 7 PR-head versions identical.
+          ALL=("$PR_PLUGIN" "$PR_GH_META" "$PR_GH_PLUGIN" "$PR_CLAUDE_TOP" "$PR_CLAUDE_PLUGIN" "$PR_CLAUDE_ADAPTER" "$PR_CODEX_ADAPTER")
           for v in "${ALL[@]}"; do
             if [[ "$v" != "$PR_PLUGIN" ]]; then
-              echo "::error::Version fields are out of sync. All 5 fields must match. Got: ${ALL[*]}"
-              echo "::error::Files to fix: plugins/winui/agent-plugin/plugin.json, .github/plugin/marketplace.json, .claude-plugin/marketplace.json"
+              echo "::error::Version fields are out of sync. All 7 fields must match. Got: ${ALL[*]}"
+              echo "::error::Files to fix: plugins/winui/agent-plugin/plugin.json, .github/plugin/marketplace.json, .claude-plugin/marketplace.json, plugins/winui/.claude-plugin/plugin.json, plugins/winui/.codex-plugin/plugin.json"
               exit 1
             fi
           done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The promotion PR (staging → main) moves entries from here into a new
   - plugins/winui/agent-plugin/plugin.json (version)
   - .github/plugin/marketplace.json (metadata.version, plugins[].version)
   - .claude-plugin/marketplace.json (version, plugins[].version)
+  - plugins/winui/.claude-plugin/plugin.json (version)
+  - plugins/winui/.codex-plugin/plugin.json (version)
 The `version-bump` and `changelog-entry` CI jobs enforce this.
 -->
 
@@ -30,6 +32,16 @@ The `version-bump` and `changelog-entry` CI jobs enforce this.
 ### Removed
 
 ### Deprecated
+
+## [0.6.1] — 2026-09-09
+
+### Fixed
+
+- Synced `plugins/winui/.claude-plugin/plugin.json` and
+  `plugins/winui/.codex-plugin/plugin.json` versions (previously stuck at
+  `0.3.0` since the Agent Plugins 1.0 package migration) to the current
+  release version. Both files are now written by the release helper and
+  checked by CI alongside the other version fields.
 
 ## [0.6.0] — 2026-08-26
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,8 @@ release/X.Y.Z ──PR──▶  main     ──backmerge/X.Y.Z ▶  staging
 - ❌ Don't edit `plugins/winui/agent-plugin/plugin.json` `version`.
 - ❌ Don't edit `.github/plugin/marketplace.json` `version` fields.
 - ❌ Don't edit `.claude-plugin/marketplace.json` `version` fields.
+- ❌ Don't edit `plugins/winui/.claude-plugin/plugin.json` `version`.
+- ❌ Don't edit `plugins/winui/.codex-plugin/plugin.json` `version`.
 - ❌ Don't add a `## [X.Y.Z]` section to `CHANGELOG.md` — write your bullets
   under `## [Unreleased]` if your change is user-facing.
 
@@ -88,7 +90,7 @@ release:
 
 1. Branch from `main`: `git checkout -b hotfix/short-description origin/main`.
 2. Fix the bug.
-3. Bump the **patch** version in all three manifests + add a `[X.Y.Z]` section
+3. Bump the **patch** version in all seven manifests + add a `[X.Y.Z]` section
    to `CHANGELOG.md` (yes, in the hotfix PR — this is the one exception).
 4. PR against `main`. CI will run the same `version-bump` + `changelog-entry`
    checks the promotion PR runs.
@@ -132,7 +134,7 @@ check will (correctly) refuse to let the version-bump diff land on staging.
 |---|---|---|
 | `pr-target-policy` | PR targets `main` | Your branch is `staging`, `release/*`, or `hotfix/*`, AND comes from this repo (not a fork). |
 | `version-sync` | PR targets `staging` | You did NOT change any version field. (Skipped on `backmerge/*`.) |
-| `version-bump` | PR targets `main` | All 5 version fields bumped, valid semver, strictly greater, identical. |
+| `version-bump` | PR targets `main` | All 7 version fields bumped, valid semver, strictly greater, identical. |
 | `changelog-entry` | PR targets `main` | Top-most `## [X.Y.Z]` section matches the bumped version, has at least one bullet. |
 | `staging-up-to-date-with-main` | PR targets `staging` | PR head contains every commit on `main` (back-merge PRs satisfy this naturally). |
 | `build-tools` + provenance | Any PR | C# tools build, analyzer tests pass, committed payloads match source. |

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -53,10 +53,12 @@ The script:
    either client-specific agent copy, removes a skill directory, or changes the plugin
    manifest schema).
 4. Lets you accept or override the suggested version.
-5. Writes the bumped version into all five version fields:
+5. Writes the bumped version into all seven version fields:
    - `plugins/winui/agent-plugin/plugin.json` → `version`
    - `.github/plugin/marketplace.json` → `metadata.version` and `plugins[0].version`
    - `.claude-plugin/marketplace.json` → `version` and `plugins[0].version`
+   - `plugins/winui/.claude-plugin/plugin.json` → `version`
+   - `plugins/winui/.codex-plugin/plugin.json` → `version`
 6. Drafts a `## [X.Y.Z] — YYYY-MM-DD` CHANGELOG section by promoting bullets
    currently under `## [Unreleased]` and grouping any unbucketed commits by
    path heuristic.
@@ -68,7 +70,7 @@ The script:
 If the helper doesn't work for some reason:
 
 1. `git checkout -b release/X.Y.Z origin/staging`
-2. Edit all five version fields (use `git grep -n '"version"'` to find them).
+2. Edit all seven version fields (use `git grep -n '"version"'` to find them).
 3. Edit `CHANGELOG.md`: rename `## [Unreleased]` to `## [X.Y.Z] — YYYY-MM-DD`
    and add a fresh empty `## [Unreleased]` section above it.
 4. Commit, push, `gh pr create --base main --head release/X.Y.Z`.
@@ -143,7 +145,7 @@ skips that prefix so the version-bump diff doesn't trip the gate.
 If a release on `main` is broken:
 
 1. `git revert -m 1 <merge-commit-sha>` on a new branch from `main`.
-2. Bump the patch version (`0.X.Y → 0.X.Y+1`) in all five fields.
+2. Bump the patch version (`0.X.Y → 0.X.Y+1`) in all seven fields.
 3. Add a CHANGELOG entry under the new version explaining what was reverted
    and why.
 4. PR against `main` directly — this is treated like a hotfix.

--- a/plugins/winui/.claude-plugin/plugin.json
+++ b/plugins/winui/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "winui",
   "description": "Agents and skills for WinUI 3 app development. Create new WinUI 3 desktop apps, convert from other frameworks to WinUI 3, or add features to existing WinUI 3 applications.",
-  "version": "0.3.0",
+  "version": "0.6.1",
   "author": {
     "name": "Microsoft",
     "url": "https://github.com/microsoft/win-dev-skills"

--- a/plugins/winui/.codex-plugin/plugin.json
+++ b/plugins/winui/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "winui",
-  "version": "0.3.0",
+  "version": "0.6.1",
   "description": "Agents and skills for WinUI 3 app development. Create new WinUI 3 desktop apps, convert from other frameworks to WinUI 3, or add features to existing WinUI 3 applications.",
   "author": {
     "name": "Microsoft",

--- a/plugins/winui/agent-plugin/plugin.json
+++ b/plugins/winui/agent-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "winui",
   "description": "Agents and skills for WinUI 3 app development. Create new WinUI 3 desktop apps, convert from other frameworks to WinUI 3, or add features to existing WinUI 3 applications.",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "author": {
     "name": "Microsoft",
     "url": "https://github.com/microsoft/win-dev-skills"

--- a/scripts/open-release-pr.ps1
+++ b/scripts/open-release-pr.ps1
@@ -11,7 +11,7 @@
     2. Lists the commits going into the release.
     3. Suggests a semver bump (patch by default; minor on heuristic triggers).
     4. Lets you accept or override the version.
-    5. Writes the version into all 5 manifest fields.
+    5. Writes the version into all 7 manifest fields.
     6. Promotes [Unreleased] CHANGELOG bullets into a new dated section.
     7. Pushes a release/X.Y.Z branch and opens the PR via gh.
 
@@ -183,12 +183,14 @@ function Set-JsonField([string]$file, [string[]]$path, [string]$value) {
   ($json | ConvertTo-Json -Depth 32) | Set-Content $file -Encoding UTF8
 }
 
-Info "Writing version into 5 fields..."
+Info "Writing version into 7 fields..."
 Set-JsonField 'plugins/winui/agent-plugin/plugin.json' @('version')             $Version
 Set-JsonField '.github/plugin/marketplace.json'     @('metadata','version')     $Version
 Set-JsonField '.github/plugin/marketplace.json'     @('plugins','[0]','version') $Version
 Set-JsonField '.claude-plugin/marketplace.json'     @('version')                $Version
 Set-JsonField '.claude-plugin/marketplace.json'     @('plugins','[0]','version') $Version
+Set-JsonField 'plugins/winui/.claude-plugin/plugin.json' @('version')           $Version
+Set-JsonField 'plugins/winui/.codex-plugin/plugin.json'  @('version')           $Version
 
 # ---- 6. Promote [Unreleased] in CHANGELOG --------------------------------
 
@@ -248,6 +250,8 @@ Set-Content CHANGELOG.md -Value $newCl -Encoding UTF8
 git add plugins/winui/agent-plugin/plugin.json `
         .github/plugin/marketplace.json `
         .claude-plugin/marketplace.json `
+        plugins/winui/.claude-plugin/plugin.json `
+        plugins/winui/.codex-plugin/plugin.json `
         CHANGELOG.md
 git commit -m "Release $Version" | Out-Null
 git push -u origin $branch


### PR DESCRIPTION
## Summary

Catches up two version fields that fell out of sync during the Agent Plugins 1.0 package migration, and closes the gap that let it happen.

- plugins/winui/.claude-plugin/plugin.json and plugins/winui/.codex-plugin/plugin.json were stuck at 